### PR TITLE
Ve definitions (adding popup modal dialog which pops up and displays info on indicator definition)

### DIFF
--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -39,6 +39,7 @@ list.files("modules", full.names = TRUE, recursive = TRUE) |>
 # 3. Required datafiles ------------------------------------------------------------
 main_dataset <- read_parquet("data/optdata") # main dataset (to do: rename optdata file in data prep script)
 geo_lookup <- readRDS("data/geo_lookup.rds") # geography lookup
+techdoc <- readRDS("data/techdoc.rds") # indicator technical info lookup
 
 # shapefiles (for map) 
 ca_bound <- readRDS("data/CA_boundary.rds") # Council area
@@ -54,9 +55,6 @@ hb_bound <- sf::st_as_sf(hb_bound)
 hscp_bound <- sf::st_as_sf(hscp_bound)
 hscloc_bound <- sf::st_as_sf(hscloc_bound)
 iz_bound <- sf::st_as_sf(iz_bound)
-
-
-
 
 
 # 4. lists ----------------------------------------------------------

--- a/shiny_app/modules/buttons/indicator_definition_btn_mod.R
+++ b/shiny_app/modules/buttons/indicator_definition_btn_mod.R
@@ -1,0 +1,35 @@
+# modal dialog box opens and displays definition of selected indicator
+
+ 
+###UI
+
+indicator_definition_btn_ui <- function(id) {
+  ns <- NS(id)
+  tagList(
+      actionButton(ns("indicator_definition"), label = "Definition",icon= icon('info'))
+    )
+
+}
+
+
+####SERVER
+
+indicator_definition_btn_server <- function(id, selected_indicator) {
+  moduleServer(
+    id,
+    function(input, output, session) {
+
+        observeEvent(input$indicator_definition, {
+        showModal(
+          modalDialog(
+            title = selected_indicator()
+          )
+        )
+      })
+
+      
+     })
+
+
+} #closer server
+

--- a/shiny_app/modules/buttons/indicator_definition_btn_mod.R
+++ b/shiny_app/modules/buttons/indicator_definition_btn_mod.R
@@ -1,4 +1,6 @@
-# modal dialog box opens and displays definition of selected indicator
+# Indicator_definition_btn_module ----
+
+# Shiny action button linked to a modal dialog box that on click opens to display full indicator definition (sourced from technical document) of the selected indicator
 
  
 ###UI
@@ -19,17 +21,27 @@ indicator_definition_btn_server <- function(id, selected_indicator) {
     id,
     function(input, output, session) {
 
+      #filter techdoc by selected indicator
+      filtered_indicator <- reactive({
+        techdoc |>
+          filter(indicator_name==selected_indicator)})
+
+      
+      #content of ModalDialog box
         observeEvent(input$indicator_definition, {
         showModal(
           modalDialog(
-            title = selected_indicator
+           title = "Definition:",
+            #insert indicator name (formatted in bold & underlined) followed by indicator definition
+            HTML(paste(sprintf("<b><u>%s</b></u> <br> %s ", selected_indicator,
+                              filtered_indicator()$indicator_definition, collapse = "<br><br>"))),
+            easyClose = TRUE,fade=FALSE,footer = modalButton("Close (Esc)") #easyclose allows you to use 'Esc' button to close modal 
           )
         )
       })
 
-      
-     })
 
-
+         }) #close module server
 } #closer server
+
 

--- a/shiny_app/modules/buttons/indicator_definition_btn_mod.R
+++ b/shiny_app/modules/buttons/indicator_definition_btn_mod.R
@@ -22,7 +22,7 @@ indicator_definition_btn_server <- function(id, selected_indicator) {
         observeEvent(input$indicator_definition, {
         showModal(
           modalDialog(
-            title = selected_indicator()
+            title = selected_indicator
           )
         )
       })

--- a/shiny_app/modules/buttons/indicator_definition_btn_mod.R
+++ b/shiny_app/modules/buttons/indicator_definition_btn_mod.R
@@ -24,7 +24,7 @@ indicator_definition_btn_server <- function(id, selected_indicator) {
       #filter techdoc by selected indicator
       filtered_indicator <- reactive({
         techdoc |>
-          filter(indicator_name==selected_indicator)})
+          filter(indicator_name == selected_indicator())})
 
       
       #content of ModalDialog box
@@ -33,7 +33,7 @@ indicator_definition_btn_server <- function(id, selected_indicator) {
           modalDialog(
            title = "Definition:",
             #insert indicator name (formatted in bold & underlined) followed by indicator definition
-            HTML(paste(sprintf("<b><u>%s</b></u> <br> %s ", selected_indicator,
+            HTML(paste(sprintf("<b><u>%s</b></u> <br> %s ", selected_indicator(),
                               filtered_indicator()$indicator_definition, collapse = "<br><br>"))),
             easyClose = TRUE,fade=FALSE,footer = modalButton("Close (Esc)") #easyclose allows you to use 'Esc' button to close modal 
           )

--- a/shiny_app/modules/visualisations/inequality.R
+++ b/shiny_app/modules/visualisations/inequality.R
@@ -23,42 +23,12 @@ inequality_ui <- function(id) {
 inequality_server <- function(id, profile_data, geo_selections) {
   moduleServer(id, function(input, output, session) {
       
-      
-    
+     
       # return selected indicator
       selected_indicator <- indicator_filter_mod_server("indicator_filter", profile_data, geo_selections)
       
-      indicator_definition_btn_server("inequalities_ind_def",selected_indicator=selected_indicator())   
-      
-      # create basic rank data - filtering by selected indicator, selected areatype and the max year
-      definition_data <- reactive({
-        profile_data() |>
-          filter(indicator == selected_indicator() & areatype == geo_selections()$areatype) |>
-          filter(year == max(year)) |>
-          arrange(measure)
-      })
-      
-      
-      
-       # Filter dataframe based on selected category
-      # indicator_to_define <- reactive({
-      #   subset(techdoc, indicator_name == input$indicator_name)
-      # })
-
-      output$filter_output <- renderText({
-        "bla"
-      })
-
-      
-      observeEvent(input$indicator_definition, {
-        showModal(
-          modalDialog(
-            title = "modal dialog title",
-            textOutput("filter_output")
-          )
-        )
-      })
-      
+      indicator_definition_btn_server("inequalities_ind_def", selected_indicator=selected_indicator())   
+     
       
 
     }

--- a/shiny_app/modules/visualisations/inequality.R
+++ b/shiny_app/modules/visualisations/inequality.R
@@ -8,7 +8,8 @@ inequality_ui <- function(id) {
       sidebar = sidebar(width = 300,
                         indicator_filter_mod_ui(ns("indicator_filter")),
                         paste0("some text"),
-                        actionButton(ns("indicator_definition"), label = "Definition", icon= icon('info'))
+                        indicator_definition_btn_ui(ns("inequalities_ind_def"))
+                        #actionButton(ns("indicator_definition"), label = "Definition", icon= icon('info'))
                         #indicator_definition_btn_ui(ns("hwb_inequality"))
       )# close sidebar
 
@@ -23,10 +24,11 @@ inequality_server <- function(id, profile_data, geo_selections) {
   moduleServer(id, function(input, output, session) {
       
       
+    
       # return selected indicator
       selected_indicator <- indicator_filter_mod_server("indicator_filter", profile_data, geo_selections)
       
-      
+      indicator_definition_btn_server("inequalities_ind_def",selected_indicator=selected_indicator())   
       
       # create basic rank data - filtering by selected indicator, selected areatype and the max year
       definition_data <- reactive({

--- a/shiny_app/modules/visualisations/inequality.R
+++ b/shiny_app/modules/visualisations/inequality.R
@@ -1,0 +1,64 @@
+inequality_ui <- function(id) {
+  ns <- NS(id)
+  tagList(
+    layout_sidebar(
+      height = 600, 
+      width = 350, 
+      padding = 20,
+      sidebar = sidebar(width = 300,
+                        indicator_filter_mod_ui(ns("indicator_filter")),
+                        paste0("some text"),
+                        actionButton(ns("indicator_definition"), label = "Definition", icon= icon('info'))
+                        #indicator_definition_btn_ui(ns("hwb_inequality"))
+      )# close sidebar
+
+      )    
+    
+  #  textOutput("selected_var"),
+    
+  )
+}
+
+inequality_server <- function(id, profile_data, geo_selections) {
+  moduleServer(id, function(input, output, session) {
+      
+      
+      # return selected indicator
+      selected_indicator <- indicator_filter_mod_server("indicator_filter", profile_data, geo_selections)
+      
+      
+      
+      # create basic rank data - filtering by selected indicator, selected areatype and the max year
+      definition_data <- reactive({
+        profile_data() |>
+          filter(indicator == selected_indicator() & areatype == geo_selections()$areatype) |>
+          filter(year == max(year)) |>
+          arrange(measure)
+      })
+      
+      
+      
+       # Filter dataframe based on selected category
+      # indicator_to_define <- reactive({
+      #   subset(techdoc, indicator_name == input$indicator_name)
+      # })
+
+      output$filter_output <- renderText({
+        "bla"
+      })
+
+      
+      observeEvent(input$indicator_definition, {
+        showModal(
+          modalDialog(
+            title = "modal dialog title",
+            textOutput("filter_output")
+          )
+        )
+      })
+      
+      
+
+    }
+  )
+}

--- a/shiny_app/modules/visualisations/inequality_mod.R
+++ b/shiny_app/modules/visualisations/inequality_mod.R
@@ -27,8 +27,11 @@ inequality_server <- function(id, profile_data, geo_selections) {
       # return selected indicator
       selected_indicator <- indicator_filter_mod_server("indicator_filter", profile_data, geo_selections)
       
+
       indicator_definition_btn_server("inequalities_ind_def", selected_indicator=selected_indicator())   
      
+
+
       
 
     }

--- a/shiny_app/modules/visualisations/inequality_mod.R
+++ b/shiny_app/modules/visualisations/inequality_mod.R
@@ -28,7 +28,7 @@ inequality_server <- function(id, profile_data, geo_selections) {
       selected_indicator <- indicator_filter_mod_server("indicator_filter", profile_data, geo_selections)
       
 
-      indicator_definition_btn_server("inequalities_ind_def", selected_indicator=selected_indicator())   
+      indicator_definition_btn_server("inequalities_ind_def", selected_indicator = selected_indicator)   
      
 
 

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -143,7 +143,6 @@ function(input, output, session) {
   # takes profile data and further filters by selected areatype
   inequality_server("hwb_inequality", profile_data, geo_selections)
   
-  indicator_definition_btn_server("hwb_inequalitites", profile_data)
   
   
 } # close main server function

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -82,18 +82,6 @@ function(input, output, session) {
   })
 
   
-# ve working
- # #trying to capture and store indicator selected name
-  
- #  indicator_name <-reactiveVal() #store full indicator name
- #  observeEvent(input$indicator_selection, {
- #    
- #    profile(input$nav) # update the object called 'profile' with the nav id (i.e. HWB)
- #    profile_name(profiles_list[[input$nav]]) # update the object called 'profile_name' with the long version of the name (i.e. Health and wellbeing)
- #  })
- #    
- #  
-    
   # data filtered by profile (input$nav stores info on the tab the user is on)
   # i.e. the alcohol tab has been assigned an id/value called 'ALC' (see ui script) so when a user selects the alcohol tab, the results of input$nav is 'ALC'
   # note: since not yet filtered by geography here, this can be used to pass to other modules to create

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -130,6 +130,13 @@ function(input, output, session) {
   rank_mod_server("pop_rank", profile_data, geo_selections)
   rank_mod_server("tob_rank", profile_data, geo_selections)
   
+  # logic controlling rank visualisations
+  # takes profile data and further filters by selected areatype
+  inequalities_layout_server("hwb_inequalitites", profile_data, geo_selections)
+  
+  indicator_definition_btn_server("hwb_inequalitites", profile_data)
+  
+  
 } # close main server function
 
 ##END

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -57,7 +57,7 @@ function(input, output, session) {
   profile_name <- reactiveVal() # to store full name (i.e. Health and Wellbeing)
   profile <- reactiveVal() # to store abbreviated name (i.e. HWB)
 
-  
+
   # when a user switches tab, update the 2 x reactive values created above 
   observeEvent(input$nav, {
     profile(input$nav) # update the object called 'profile' with the nav id (i.e. HWB)
@@ -82,8 +82,17 @@ function(input, output, session) {
   })
 
   
+# ve working
+ # #trying to capture and store indicator selected name
   
-  
+ #  indicator_name <-reactiveVal() #store full indicator name
+ #  observeEvent(input$indicator_selection, {
+ #    
+ #    profile(input$nav) # update the object called 'profile' with the nav id (i.e. HWB)
+ #    profile_name(profiles_list[[input$nav]]) # update the object called 'profile_name' with the long version of the name (i.e. Health and wellbeing)
+ #  })
+ #    
+ #  
     
   # data filtered by profile (input$nav stores info on the tab the user is on)
   # i.e. the alcohol tab has been assigned an id/value called 'ALC' (see ui script) so when a user selects the alcohol tab, the results of input$nav is 'ALC'
@@ -130,9 +139,9 @@ function(input, output, session) {
   rank_mod_server("pop_rank", profile_data, geo_selections)
   rank_mod_server("tob_rank", profile_data, geo_selections)
   
-  # logic controlling rank visualisations
+  # logic controlling inequalities layout page
   # takes profile data and further filters by selected areatype
-  inequalities_layout_server("hwb_inequalitites", profile_data, geo_selections)
+  inequality_server("hwb_inequality", profile_data, geo_selections)
   
   indicator_definition_btn_server("hwb_inequalitites", profile_data)
   

--- a/shiny_app/ui.R
+++ b/shiny_app/ui.R
@@ -76,7 +76,7 @@ page_navbar(
                 nav_panel(title = "Summary", summary_table_ui("hwb_summary")),
                 nav_panel(title = "Trends"),
                 nav_panel(title = "Rank", rank_mod_ui("hwb_rank")),
-                nav_panel(title = "Inequalities"))),
+                nav_panel(title = "Inequalities", inequalities_layout_ui("hwb_inequalities")))),
 
     # Children and young people
     nav_panel(value = "CYP",

--- a/shiny_app/ui.R
+++ b/shiny_app/ui.R
@@ -76,7 +76,7 @@ page_navbar(
                 nav_panel(title = "Summary", summary_table_ui("hwb_summary")),
                 nav_panel(title = "Trends"),
                 nav_panel(title = "Rank", rank_mod_ui("hwb_rank")),
-                nav_panel(title = "Inequalities", inequalities_layout_ui("hwb_inequalities")))),
+                nav_panel(title = "Inequalities", inequality_ui("hwb_inequality")))),
 
     # Children and young people
     nav_panel(value = "CYP",


### PR DESCRIPTION
If you run my code you should find within the health and wellbeing profile (in the inequality tab) a drop down filter for indicators and a definitions button. The idea is this will be a module that can be inserted into any time and will display indicator definitions taken from the techdoc. I have it sort of working however at the moment there must be a problem with the reactivity so the definition displayed works once but then doesn't update when you change the filter selection. I'm sorry i've run out of time to fix this but i wondered if either of you had any idea about where i'm going wrong.  To run the branch you'll need to take a copy of the techdoc from either the network folder or from my analyst folder (if you can find the repo in amongst the chaos!)