### PR TITLE
add optional domain order arg to module and add title to sparklines

### DIFF
--- a/shiny_app/modules/visualisations/summary_table_mod.R
+++ b/shiny_app/modules/visualisations/summary_table_mod.R
@@ -41,7 +41,7 @@ summary_table_ui <- function(id) {
 # selected_profile = name of reactive value storing selected profile
 # filtered_data = name of reactive dataframe where data has already been filtered by profile 
 
-summary_table_server <- function(id, selected_geo, selected_profile, filtered_data) {
+summary_table_server <- function(id, selected_geo, selected_profile, filtered_data, domain_order = NULL) {
   
   moduleServer(id, function(input, output, session) {
     
@@ -79,6 +79,20 @@ summary_table_server <- function(id, selected_geo, selected_profile, filtered_da
       
       # Arrange by 'domain'
       chosen_area <- setorder(chosen_area, domain)
+      
+      if(is.null(domain_order)) {
+        
+        # Arrange by 'domain'
+        chosen_area <- setorder(dt, domain)
+        
+      } else {
+        
+        # arrange by 'domain' with custom sort order
+        chosen_area <- chosen_area[, domain := factor(domain, levels = domain_order)]
+        chosen_area <- setorder(dt, domain)
+        
+      }
+      
       
       # assign colours to values depending on statistical significance
       final <- chosen_area %>%
@@ -163,6 +177,8 @@ summary_table_server <- function(id, selected_geo, selected_profile, filtered_da
       dt <- dt[,.(measures = list(measure), # for the trend chart 
                   years = list(year), # for the trend chart 
                   domain = first(domain), # for the table 
+                  trend_min = first(trend_axis), # for the trend chart label
+                  trend_max = last(trend_axis),
                   def_period = last(def_period), # for the table
                   type_definition = first(type_definition), # for the table
                   measure = first(measure)),# for the table
@@ -175,8 +191,17 @@ summary_table_server <- function(id, selected_geo, selected_profile, filtered_da
       # set domain column as the first in the table
       setcolorder(dt, "domain")
       
+      if(is.null(domain_order)) {
+      
       # Arrange by 'domain'
       dt <- setorder(dt, domain)
+      
+      } else {
+        
+      dt <- dt[, domain := factor(domain, levels = domain_order)]
+      dt <- setorder(dt, domain)
+        
+      }
       
       dt
       
@@ -359,6 +384,7 @@ summary_table_server <- function(id, selected_geo, selected_profile, filtered_da
             function(rowInfo) {
               var containerId = rowInfo.row.unique_id;
               var chartHTML = '<div id=\"' + containerId + '\" style=\"height: 100px; width: 100%\"></div>';
+              var time_period = rowInfo.row.trend_min + ' - ' + rowInfo.row.trend_max;
               
               setTimeout(function() {
                 Highcharts.chart(containerId, {
@@ -367,15 +393,15 @@ summary_table_server <- function(id, selected_geo, selected_profile, filtered_da
                     animation: false
                   },
                   title: {
-                    text: ''
+                    text: time_period,
+                     style: {
+                      fontSize: '12px'
+                    }
                   },
                   xAxis: {
                     categories: rowInfo.row.years,
                     labels: {
                       enabled: false
-                    },
-                    title: {
-                      text: null
                     },
                     tickLength: 0,
                     lineWidth: 0
@@ -441,7 +467,9 @@ summary_table_server <- function(id, selected_geo, selected_profile, filtered_da
                      years = colDef(show = FALSE),
                      measures = colDef(show = FALSE),
                      type_definition = colDef(show = FALSE),
-                     unique_id = colDef(show = FALSE)
+                     unique_id = colDef(show = FALSE),
+                     trend_min = colDef(show = FALSE),
+                     trend_max = colDef(show = FALSE)
                      )
       } else {
         cols <- list(domain = domain, 

--- a/shiny_app/modules/visualisations/summary_table_mod.R
+++ b/shiny_app/modules/visualisations/summary_table_mod.R
@@ -83,13 +83,13 @@ summary_table_server <- function(id, selected_geo, selected_profile, filtered_da
       if(is.null(domain_order)) {
         
         # Arrange by 'domain'
-        chosen_area <- setorder(dt, domain)
+        chosen_area <- setorder(chosen_area, domain)
         
       } else {
         
         # arrange by 'domain' with custom sort order
         chosen_area <- chosen_area[, domain := factor(domain, levels = domain_order)]
-        chosen_area <- setorder(dt, domain)
+        chosen_area <- setorder(chosen_area, domain)
         
       }
       

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -153,7 +153,7 @@ function(input, output, session) {
   # prepares summary data and displays in a table with spinecharts
   summary_table_server("hwb_summary", geo_selections, profile_name, profile_data)
   summary_table_server("cyp_summary", geo_selections, profile_name, profile_data)
-  summary_table_server("cwb_summary", geo_selections, profile_name, profile_data)
+  summary_table_server("cwb_summary", geo_selections, profile_name, profile_data, domain_order = c("Over-arching indicators", "Early years", "Healthy places", "Impact of ill health prevention"))
   summary_table_server("alc_summary", geo_selections, profile_name, profile_data)
   summary_table_server("drg_summary", geo_selections, profile_name, profile_data)
   summary_table_server("men_summary", geo_selections, profile_name, profile_data)


### PR DESCRIPTION
2 small tweaks for the summary tab:

1. re-ordering CWB domains. I've created an optional argument in the module to re-order domains in case we need to do this for any other profiles at some point.
2. 
3. Adding titles to the sparklines to show time period (not sure if we would want tooltips for the sparklines too or not?)

The ordering of domains should I think carry over to the rmarkdown script for the PDF but I still need to add the titles for the trend lines at some point, but will probably be a lot of fiddling around with row heights etc. to get it to fit, so will add to my list.