### PR TITLE
Mm improve chart downloads

### DIFF
--- a/shiny_app/modules/buttons/chart_download_mod.R
+++ b/shiny_app/modules/buttons/chart_download_mod.R
@@ -13,6 +13,7 @@
 
 # UI function:
 # id = unique id
+# see https://www.highcharts.com/docs/export-module/export-module-overview 
 download_chart_mod_ui <- function(id) {
   ns <- NS(id)
   tagList(
@@ -22,8 +23,10 @@ download_chart_mod_ui <- function(id) {
       var chartIndex = Highcharts.charts.findIndex(function(chart) {
         return chart && chart.renderTo.id === message.chartId;
       });
-      Highcharts.charts[chartIndex].exportChart();
-
+        Highcharts.charts[chartIndex].exportChart({
+          sourceWidth: message.width,
+          sourceHeight: message.height
+        });
     });"
       )
     ),
@@ -31,19 +34,20 @@ download_chart_mod_ui <- function(id) {
   )
 }
 
-
-
 # Server function:
 # id = unique id
 # chart_id = the inputId used for the chart displayed in the dashboard
-
-download_chart_mod_server <- function(id, chart_id) {
+download_chart_mod_server <- function(id, chart_id, width = 600, height = 400) {
   moduleServer(id, function(input, output, session) {
+    
+    
     
     # when button clicked, trigger the JS code to run
     observeEvent(input$chart_download, {
       session$sendCustomMessage("triggerDownload",
-                                list(chartId = chart_id)
+                                list(chartId = chart_id,
+                                     width = width,
+                                     height = height)
       )
     })
   })

--- a/shiny_app/modules/visualisations/pop_groups_mod.R
+++ b/shiny_app/modules/visualisations/pop_groups_mod.R
@@ -289,11 +289,13 @@ pop_groups_server <- function(id, dataset, geo_selections) {
         hc_yAxis(title = list(text = "")) %>%
         hc_plotOptions(series = list(animation = FALSE),
                        column = list(groupPadding = 0))|>
-        # add extra bits to chart for downloaded version (still need to add subtitles?)
+        # add extra bits to chart for downloaded version
         hc_exporting(
+          filename = paste0("ScotPHO ", selected_indicator(), " split by ", input$split_filter),
           chartOptions = list(
-            title = list(text = paste0(selected_indicator(), "split by ", input$split_filter, 
-                                       " for time period: ",pop_rank_data()$trend_axis[1]))
+            title = list(text = paste0(selected_indicator(), " split by ", input$split_filter)),
+            subtitle = list(text = paste0(pop_rank_data()$trend_axis[1])),
+            yAxis = list(title = list(text = paste0(pop_rank_data()$rate_type[1])))
           )
         )
       
@@ -344,10 +346,13 @@ pop_groups_server <- function(id, dataset, geo_selections) {
           borderWidth = 1,
           table = TRUE
         ) |>
-        # add extra bits to chart for downloaded version (still need to add subtitles?)
+        # add extra bits to chart for downloaded version
         hc_exporting(
+          filename = paste0("ScotPHO trend - ", selected_indicator(), " split by ", input$split_filter),
           chartOptions = list(
-            title = list(text = paste0(selected_indicator(), " split by ", input$split_filter))
+            title = list(text = paste0(selected_indicator(), " split by ", input$split_filter)),
+            subtitle = list(text = paste0(first(pop_trend_data()$trend_axis)," to ",last(pop_trend_data()$trend_axis))),
+            yAxis = list(title = list(text = paste0(pop_trend_data()$rate_type[1])))
           )
         )
       

--- a/shiny_app/modules/visualisations/rank_charts_mod.R
+++ b/shiny_app/modules/visualisations/rank_charts_mod.R
@@ -283,7 +283,7 @@ rank_mod_server <- function(id, profile_data, geo_selections) {
       
       # further filter if HSCL or IZ selected, 
       if(geo_selections()$areatype == "HSC locality"){
-        x <- x |> filter(hscp2019name == geo_selections()$parent_area)
+        x <- x |> filter(parent_area == geo_selections()$parent_area)
       } else if(geo_selections()$areatype == "Intermediate zone"){
         x <- x |> filter(council == geo_selections()$parent_area)
       } else{ 
@@ -343,26 +343,7 @@ rank_mod_server <- function(id, profile_data, geo_selections) {
       
     })
     
-    
-    # # info to display when user clicks help button (explains how to interpret)
-    # output$rank_help <- renderUI({ 
-    #   req(selected_indicator())
-    #   tagList(
-    #     tags$h5("How to use this chart"),
-    #     p(paste0("The charts below allow you rank each ", geo_selections()$areatype, " for your selected indicator (in this case, ", selected_indicator(), ").")),
-    #     p("You can also choose to add a baseline comparator, to assess whether each area in your chosen geography level is statistically significantly better or worse than your comparator."),
-    #     p("For example, you may want to assess whether each ", geo_selections()$areatype, " is significantly higher or lower than a particular geographical area (for instance, the national average) or
-    #              whether there are particular areas in your chosen geography level that are significantly higher or lower than they were at another point in time (e.g. a decade ago)"),
-    #     br(),
-    #     p("If a comparator is selected, the chart and the map will be colour coded using the key below:"),
-    #     fluidRow(span(tags$div(style = "width:30px; height:30px; background-color:orange; border-radius:50%; display:inline-block; margin:5px;"), "orange - statistically significantly better")),
-    #     fluidRow(span(tags$div(style = "width:30px; height:30px; background-color:blue; border-radius:50%; display:inline-block; margin:5px;"), "blue - statistically significantly worse")),
-    #     fluidRow(span(tags$div(style = "width:30px; height:30px; background-color:gray; border-radius:50%; display:inline-block; margin:5px;"), "grey - not statistically different to Scotland")),
-    #     fluidRow(span(tags$div(style = "width:30px; height:30px; background-color:white; border:1px solid black; outline-color:black; border-radius:50%; display:inline-block; margin:5px;"), "white - no difference to be calculated"))
-    #     
-    #   )
-    # })
-    
+
     
     ############################################
     # Visualisations / data table  ----
@@ -380,6 +361,32 @@ rank_mod_server <- function(id, profile_data, geo_selections) {
           
 Not all profiles have available indicators for all geography types. The drugs profile has no available indicators for intermediate zones and the mental health profile has no available indicators for intermediate zones or HSC localities. Please select another profile or geography type to continue.")
       )
+      
+      
+      
+      # get definition period
+      max_year <- rank_data()$def_period[1]
+      
+      # prepare areaname (including parent area if IZ/HSCL selected)
+      area <- if(geo_selections()$areatype == "HSC locality") {
+        paste("HSC Localities in ",geo_selections()$parent_area)
+      } else if(geo_selections()$areatype == "Intermediate zone"){
+        paste("Intermediate zones in ",geo_selections()$parent_area)
+      } else {
+        geo_selections()$areatype
+      }
+      
+      # prepare description of what map/chart show depending on
+      # whether comparator included (and if so which comparator)
+      chart_desc <- if(input$comparator_switch == TRUE){
+        if(input$comparator_type == "Area"){
+          tags$p(paste(area,"comparison against",input$area_comparator, " - ", max_year))
+        } else if(input$comparator_type == "Time"){
+          tags$p(area,"- ",max_year,"compared to ",input$year_comparator)
+        }
+      } else {
+        tags$p(area, " - ", max_year)
+      }
       
       # if there' no comparator selected, or the selected comparator is "area" then create a bar chart
       if(input$comparator_switch == FALSE | (input$comparator_switch == TRUE & input$comparator_type == "Area")) {
@@ -404,8 +411,11 @@ Not all profiles have available indicators for all geography types. The drugs pr
           ) |>
           # title for downloaded version
           hc_exporting(
+            filename = paste0("ScotPHO rank - ", selected_indicator(), " - ", geo_selections()$areatype),
             chartOptions = list(
-              title = list(text = paste0(selected_indicator()))
+              title = list(text = paste0(selected_indicator(), " split by ", geo_selections()$areatype)),
+              subtitle = list(text = paste0(chart_desc)),
+              yAxis = list(title = list(text = paste0(unique(rank_data()$type_definition))))
             )
           )
         
@@ -548,7 +558,14 @@ Not all profiles have available indicators for all geography types. The drugs pr
      ######################################
      
      # note these are both modules 
-     download_chart_mod_server(id = "save_rank_chart", chart_id = session$ns("rank_chart")) # save chart as png
+     download_chart_mod_server(id = "save_rank_chart", 
+                               chart_id = session$ns("rank_chart"), 
+                               height = if(geo_selections()$areatype == "Intermediate zone") {
+                              1200 } else if(geo_selections()$areatype == "Health board") {
+                               600 } else if(geo_selections()$areatype %in% c("Council area", "HSC partnership", "Alcohol & drug partnership", "HSC locality")) {
+                               700 } else {
+                                 500
+                               }) # save chart as png
      
      download_data_btns_server(id = "rank_download", 
                                data = rank_data, 

--- a/shiny_app/modules/visualisations/simd_mod.R
+++ b/shiny_app/modules/visualisations/simd_mod.R
@@ -3,14 +3,14 @@
 # add in help text to explain charts for help button - we need simd button and help button?
 
 
-################################
+################################.
 # MODULE: simd_navpanel_mod ---- 
 # prepares the nav_panel layout displaying SIMD based deprivation data
-################################
+################################.
 
-#######################################################
+#######################################################.
 ## MODULE UI
-#######################################################
+#######################################################.
 
 ## ui function -----------------------------------------------------------------------
 # id = unique id 
@@ -139,18 +139,18 @@ simd_navpanel_ui <- function(id) {
 
 
 
-#######################################################
+#######################################################.
 ## MODULE SERVER
-#######################################################
+#######################################################.
 
 
 simd_navpanel_server <- function(id, simd_data, geo_selections) {
   moduleServer(id, function(input, output, session) {
     
     
-    #######################################################
+    #######################################################.
     ## Dynamic filters -----
-    ######################################################
+    #######################################################.
     
     # update years choices for bar chart filter, depending on indicator selected
     observe({
@@ -195,9 +195,9 @@ simd_navpanel_server <- function(id, simd_data, geo_selections) {
     })
     
     
-    #######################################################
+    #######################################################.
     ## Reactive data / values ----
-    #######################################################
+    #######################################################.
     
     # generate list of indicators (from the simd indicators dataset) available 
     selected_indicator <- indicator_filter_mod_server(id="simd_indicator_filter", simd_data, geo_selections)
@@ -259,9 +259,9 @@ simd_navpanel_server <- function(id, simd_data, geo_selections) {
     })
     
     
-    #######################################################
+    #######################################################.
     ## dynamic text  ----
-    #######################################################
+    #######################################################.
     
     
     # bar chart title ---------
@@ -312,9 +312,9 @@ simd_navpanel_server <- function(id, simd_data, geo_selections) {
     })
     
     
-    ############################################
+    #############################################.
     # charts -----
-    #############################################
+    #############################################.
     
     # trend chart ---------------
     output$simd_trendchart <- renderHighchart({
@@ -449,9 +449,9 @@ simd_navpanel_server <- function(id, simd_data, geo_selections) {
     })
     
     
-    ##########################################
-    # Tables ---------
-    ###########################################
+    ###########################################.
+    # Tables ----
+    ###########################################.
     
     # trend data table -------
     output$trend_table <- renderReactable({
@@ -489,9 +489,9 @@ simd_navpanel_server <- function(id, simd_data, geo_selections) {
     })
     
     
-    ############################################
+    #############################################.
     # Downloads  ----
-    #############################################
+    #############################################.
     
     download_chart_mod_server(id = "save_simd_barchart", chart_id = session$ns("simd_barchart"))
     download_chart_mod_server(id = "save_simd_trendchart", chart_id = session$ns("simd_trendchart"))

--- a/shiny_app/modules/visualisations/simd_mod.R
+++ b/shiny_app/modules/visualisations/simd_mod.R
@@ -353,10 +353,13 @@ simd_navpanel_server <- function(id, simd_data, geo_selections) {
           borderWidth = 1,
           table = TRUE
         ) |>
-        # add extra bits to chart for downloaded version (still need to add subtitles?)
+        # add extra bits to chart for downloaded version
         hc_exporting(
+          filename = paste0("ScotPHO SIMD trend - ", selected_indicator()),
           chartOptions = list(
-            title = list(text = paste0(selected_indicator(), " split by SIMD Quintile"))
+            title = list(text = paste0(selected_indicator(), " split by SIMD Quintile")),
+            subtitle = list(text = paste0(first(trend_data()$trend_axis)," to ",last(trend_data()$trend_axis))),
+            yAxis = list(title = list(text = paste0(unique(trend_data()$type_definition))))
           )
         )
       
@@ -415,8 +418,11 @@ simd_navpanel_server <- function(id, simd_data, geo_selections) {
         hc_plotOptions(series = list(animation = FALSE),
                        column= list(groupPadding  = 0)) |>  # Reduce padding between groups of columns
         hc_exporting(
+          filename = paste0("ScotPHO SIMD - ", selected_indicator()),
           chartOptions = list(
-            title = list(text = paste0(selected_indicator(), " split by SIMD Quintile"))
+            title = list(text = paste0(selected_indicator(), " split by SIMD Quintile")),
+            subtitle = list(text = paste0(unique(bar_data()$trend_axis))),
+            yAxis = list(title = list(text = paste0(unique(trend_data()$type_definition))))
           )
         )
       

--- a/shiny_app/modules/visualisations/trend_mod.R
+++ b/shiny_app/modules/visualisations/trend_mod.R
@@ -448,6 +448,7 @@ trend_mod_server <- function(id, filtered_data, geo_selections, techdoc) {
         
         # title for downloaded version
         hc_exporting(
+          filename = paste0("ScotPHO trend - ", selected_indicator()),
           chartOptions = list(
             title = list(text = paste0(selected_indicator())),
             subtitle = list(text = paste0(first(trend_data()$trend_axis)," to ",last(trend_data()$trend_axis)))


### PR DESCRIPTION
This PR just improves the chart downloads. Before, the size of the PNG matched the size the chart was on the screen. Now, I've made height and width an argument of the module so that the chart downloads can look better as some were a bit squashed before i.e. if you downloaded an IZ rank chart, it will be longer than if you downloaded a health board rank chart. I've also just added some axis labels, subtitles to the downloads and made the filenames custom too so they don't all just say 'chart'.