### PR TITLE
Wider app relevance: tweaks to resolve some issues I encountered

### DIFF
--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -32,6 +32,7 @@ library(tidyr) # for pivot longer used in meta data tab
 
 
 library(readr) #im additiona will remove in future
+library(tibble) #need for indicator_filter_mod fix: https://github.com/Rdatatable/data.table/issues/3745#issuecomment-1380723524
 
 
 # 2. Sourcing modules, narrative text and guided tours  ------------------------

--- a/shiny_app/modules/filters/indicator_filter_mod.R
+++ b/shiny_app/modules/filters/indicator_filter_mod.R
@@ -24,6 +24,8 @@ indicator_filter_mod_server <- function(id, filtered_data, geo_selections) {
       
       all <- setDT(filtered_data())
       
+      all <- all %>% data.table() %>% as.tibble() %>% as.data.table() # fix from https://github.com/Rdatatable/data.table/issues/3745#issuecomment-1380723524
+      
       # filter data by selected geography to get available indicators for selected profile
       all <- all[areatype == geo_selections()$areatype & areaname == geo_selections()$areaname]
       

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -170,7 +170,7 @@ function(input, output, session) {
   
   
   # run the module containing server logic for the  rank tab - this is visible for every single profile
-  rank_mod_server("rank", areatype_data, geo_selections)
+  rank_mod_server("rank", areatype_data, geo_selections, techdoc)
   
   
   # run the module containing the server logic for the  deprivation tab ONLY when specific profiles are selected, otherwise hide the tab
@@ -178,7 +178,7 @@ function(input, output, session) {
     req(input$profile_choices != "")
     if (profiles_list[[input$profile_choices]] %in% c("CWB", "HWB", "POP", "CYP") & !is.null(profiles_list[[input$profile_choices]])) {
       nav_show("sub_tabs", target = "simd_tab")
-      simd_navpanel_server("simd", simd_data, geo_selections)
+      simd_navpanel_server("simd", simd_data, geo_selections, techdoc)
       
     } else {
       nav_hide("sub_tabs", target = "simd_tab")


### PR DESCRIPTION
Wider relevance than just mental health: corrections to 2 server.R server function calls (threw an error for me without the addition of techdoc to these functions), and a fix to indicator_filter_mod that was needed to get it to work for me (otherwise got 'internal error'). Seems odd that others obviously have got the app to work without these... maybe it's a package version thing? Which reminds me: James Fixter said the data sci team strongly recommend the use of renv to keep packages consistent across multiple contributors, and particularly with geospatial packages. 