### PR TITLE
ER connect lines across gaps

### DIFF
--- a/shiny_app/modules/visualisations/pop_groups_mod.R
+++ b/shiny_app/modules/visualisations/pop_groups_mod.R
@@ -305,7 +305,8 @@ pop_groups_server <- function(id, dataset, geo_selections) {
                }
              }"))) |>
         hc_chart(backgroundColor = 'white') |>
-        hc_plotOptions(series = list(animation = FALSE)) |>
+        hc_plotOptions(series = list(animation = FALSE,
+                                     connectNulls=TRUE)) |>
         hc_tooltip(
           crosshairs = TRUE,
           borderWidth = 1,

--- a/shiny_app/modules/visualisations/simd_mod.R
+++ b/shiny_app/modules/visualisations/simd_mod.R
@@ -357,7 +357,8 @@ simd_navpanel_server <- function(id, simd_data, geo_selections){
                }
              }"))) |>
         hc_chart(backgroundColor = 'white') |>
-        hc_plotOptions(series = list(animation = FALSE)) |>
+        hc_plotOptions(series = list(animation = FALSE,
+                                     connectNulls=TRUE)) |>
         hc_tooltip(
           crosshairs = TRUE,
           borderWidth = 1,

--- a/shiny_app/modules/visualisations/summary_table_mod.R
+++ b/shiny_app/modules/visualisations/summary_table_mod.R
@@ -485,7 +485,7 @@ summary_table_server <- function(id, selected_geo, selected_profile, filtered_da
               setTimeout(function() {
                 Highcharts.chart(containerId, {
                   chart: {
-                    type: 'line',
+                    type: 'area',
                     backgroundColor:'transparent',
                     animation: false
                   },
@@ -538,7 +538,7 @@ summary_table_server <- function(id, selected_geo, selected_profile, filtered_da
                     plotOptions: {
                       series: {
                         animation: false,
-                        stacking: 'normal',
+                        connectNulls: true,
                         dataLabels: {
                           enabled: false
                         },

--- a/shiny_app/modules/visualisations/trend_mod.R
+++ b/shiny_app/modules/visualisations/trend_mod.R
@@ -455,7 +455,8 @@ trend_mod_server <- function(id, filtered_data, geo_selections) {
                       hcaes(x = trend_axis, y = y, group = areaname),
                       marker = list(enabled = TRUE)
                       ) |>
-        hc_plotOptions(series=list(animation=FALSE)) |>
+        hc_plotOptions(series=list(animation=FALSE,
+                                   connectNulls=TRUE)) |>
         hc_yAxis(gridLineWidth = 0) |> # remove gridlines 
         hc_yAxis(title = list(text = type_definition)) |>
         hc_xAxis(categories = unique(trend_data()$trend_axis), title = "") |>

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -176,7 +176,7 @@ function(input, output, session) {
   # run the module containing the server logic for the  deprivation tab ONLY when specific profiles are selected, otherwise hide the tab
   observe({
     req(input$profile_choices != "")
-    if (profiles_list[[input$profile_choices]] %in% c("CWB", "HWB", "POP", "CYP") & !is.null(profiles_list[[input$profile_choices]])) {
+    if (profiles_list[[input$profile_choices]] %in% c("CWB", "HWB", "POP", "CYP", "MEN") & !is.null(profiles_list[[input$profile_choices]])) {
       nav_show("sub_tabs", target = "simd_tab")
       simd_navpanel_server("simd", simd_data, geo_selections)
       
@@ -302,7 +302,7 @@ function(input, output, session) {
   # filters the deprivation dataset by selected profile, filtered data then passed to the depriavtion visualisation module 
   simd_data <- reactive({
     
-    req(profiles_list[[input$profile_choices]] %in% c("HWB", "CWB", "POP", "CYP")) # only run when specific profiles have been selected
+    req(profiles_list[[input$profile_choices]] %in% c("HWB", "CWB", "POP", "CYP", "MEN")) # only run when specific profiles have been selected
 
     dt <- setDT(simd_dataset) # set to class data.table
 


### PR DESCRIPTION
PR to add connectNulls=TRUE to trend charts, so that markers get connected by a line across data gaps. PR also adds area under the summary tab sparkline, to aid interpretation (needs some additional styling from a highcharter person), and include the mental health profile in the SIMD tab logic.