### PR TITLE
ER Adding mental health indicators to the app

### DIFF
--- a/data_preparation/update_shapefiles.R
+++ b/data_preparation/update_shapefiles.R
@@ -12,6 +12,7 @@ hscp_bound <- readRDS(paste0(shape_files,"HSCP_boundary.rds"))# HSC Partnerships
 hscloc_bound <- readRDS(paste0(shape_files,"HSC_locality_boundary.rds")) # HSC localities
 iz_bound <- readRDS(paste0(shape_files,"IZ_boundary.rds")) # Intermediate zone
 #scot_bound <- readRDS("data/scot_bound.rds") # scotland
+pd_bound <- readRDS(paste0(shape_files,"PD_boundary.rds")) # # Police divisions (for mental health profile only)
 
 
 # transform so in right format to join to main dataset 
@@ -23,6 +24,7 @@ hscp_bound <- sf::st_as_sf(hscp_bound)
 hscloc_bound <- sf::st_as_sf(hscloc_bound)
 iz_bound <- sf::st_as_sf(iz_bound)
 #scot_bound <- sf::st_as_sf(scot_bound)
+pd_bound <- sf::st_as_sf(pd_bound)
 
 # 
 write_rds(ca_bound,"shiny_app/data/CA_boundary.rds")
@@ -30,6 +32,7 @@ write_rds(hb_bound,"shiny_app/data/HB_boundary.rds")
 write_rds(hscp_bound,"shiny_app/data/HSCP_boundary.rds")
 write_rds(hscloc_bound,"shiny_app/data/HSC_locality_boundary.rds")
 write_rds(iz_bound,"shiny_app/data/IZ_boundary.rds")
+write_rds(pd_bound,"shiny_app/data/PD_boundary.rds")
 
 }
 

--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -33,7 +33,6 @@ library(tidyr) # for pivot longer used in meta data tab
 
 library(readr) #im additiona will remove in future
 
-
 # 2. Sourcing modules, narrative text and guided tours  ------------------------
 list.files("modules", full.names = TRUE, recursive = TRUE) |>
   map(~ source(.))
@@ -64,6 +63,7 @@ hb_bound <- readRDS("data/HB_boundary.rds") # Health board
 hscp_bound <- readRDS("data/HSCP_boundary.rds")# HSC Partnerships
 hscloc_bound <- readRDS("data/HSC_locality_boundary.rds") # HSC localities
 iz_bound <- readRDS("data/IZ_boundary.rds") # Intermediate zone
+pd_bound <- readRDS("data/PD_boundary.rds") # Police divisions
 
 
 # transform shapefiles - needs to be done here or else app doesn't work?!
@@ -73,6 +73,7 @@ hb_bound <- sf::st_as_sf(hb_bound)
 hscp_bound <- sf::st_as_sf(hscp_bound)
 hscloc_bound <- sf::st_as_sf(hscloc_bound)
 iz_bound <- sf::st_as_sf(iz_bound)
+pd_bound <- sf::st_as_sf(pd_bound)
 
 
 # 4. lists ----------------------------------------------------------
@@ -107,6 +108,7 @@ ca_list <- sort(geo_lookup$areaname[geo_lookup$areatype=="Council area"])
 adp_list <- sort(geo_lookup$areaname[geo_lookup$areatype=="Alcohol & drug partnership"])
 hsc_loc_list <- sort(geo_lookup$areaname[geo_lookup$areatype== "HSC locality"])
 imz_list <- sort(geo_lookup$areaname[geo_lookup$areatype== "Intermediate zone"])
+pd_list <- sort(geo_lookup$areaname[geo_lookup$areatype=="Police division"])
 
 
 # geography areatypes
@@ -116,6 +118,7 @@ areatype_list <- c("Alcohol & drug partnership",
                    "HSC locality", 
                    "HSC partnership",  
                    "Intermediate zone",
+                   "Police division",
                    "Scotland")
 
 

--- a/shiny_app/modules/visualisations/pop_groups_mod.R
+++ b/shiny_app/modules/visualisations/pop_groups_mod.R
@@ -246,7 +246,6 @@ pop_groups_server <- function(id, dataset, geo_selections) {
         hc_yAxis(gridLineWidth = 0) %>%
         hc_chart(backgroundColor = 'white') %>%
         hc_xAxis(title = list(text = "")) %>%
-        hc_xAxis(categories = unique(pop_trend_data()$split_value)) |>
         hc_yAxis(title = list(text = "")) %>%
         hc_plotOptions(series = list(animation = FALSE),
                        column = list(groupPadding = 0))|>
@@ -289,6 +288,7 @@ pop_groups_server <- function(id, dataset, geo_selections) {
                   hcaes(x = trend_axis, y = measure, group = split_value)) |>
         hc_yAxis(gridLineWidth = 0) |> # remove gridlines 
         hc_xAxis(title = list(text = "")) |>
+        hc_xAxis(categories = unique(pop_trend_data()$trend_axis)) |>
         hc_yAxis(title = list(text = "")) |>
         # style xaxis labels - keeping only first and last label
         hc_xAxis(labels = list(

--- a/shiny_app/modules/visualisations/pop_groups_mod.R
+++ b/shiny_app/modules/visualisations/pop_groups_mod.R
@@ -246,7 +246,7 @@ pop_groups_server <- function(id, dataset, geo_selections) {
         hc_yAxis(gridLineWidth = 0) %>%
         hc_chart(backgroundColor = 'white') %>%
         hc_xAxis(title = list(text = "")) %>%
-        hc_xAxis(categories = unique(pop_trend_data()$trend_axis)) |>
+        hc_xAxis(categories = unique(pop_trend_data()$split_value)) |>
         hc_yAxis(title = list(text = "")) %>%
         hc_plotOptions(series = list(animation = FALSE),
                        column = list(groupPadding = 0))|>

--- a/shiny_app/modules/visualisations/rank_charts_mod.R
+++ b/shiny_app/modules/visualisations/rank_charts_mod.R
@@ -299,7 +299,8 @@ rank_mod_server <- function(id, profile_data, geo_selections) {
                   "Council area" = ca_bound,
                   "HSC partnership" = hscp_bound,
                   "HSC locality" = hscloc_bound,
-                  "Intermediate zone" = iz_bound
+                  "Intermediate zone" = iz_bound,
+                  "Police division" = pd_bound
       )
       
       # further filter if HSCL or IZ selected, 
@@ -585,7 +586,7 @@ Not all profiles have available indicators for all geography types. The drugs pr
      download_chart_mod_server(id = "save_rank_chart", 
                                chart_id = ns("rank_chart"), 
                                height = if(geo_selections()$areatype == "Intermediate zone") {
-                              1200 } else if(geo_selections()$areatype == "Health board") {
+                              1200 } else if(geo_selections()$areatype %in% c("Health board", "Police division")) {
                                600 } else if(geo_selections()$areatype %in% c("Council area", "HSC partnership", "Alcohol & drug partnership", "HSC locality")) {
                                700 } else {
                                  500

--- a/shiny_app/modules/visualisations/simd_mod.R
+++ b/shiny_app/modules/visualisations/simd_mod.R
@@ -172,30 +172,37 @@ simd_navpanel_server <- function(id, simd_data, geo_selections){
     
     
     observe({
-      # if scotland is selected or the selected indicator is patients per GP (not available at local quintiles)
+      
+      # if local quintiles are not available for the selected indicator and geography
       # then set selected quintile to "Scotland" and disable the filter
       
-      if(geo_selections()$areatype == "Scotland" | selected_indicator() == "Patients per general practitioner"){
-        updateRadioButtons(session, "quint_type", selected = "Scotland")
-        shinyjs::disable("quint_type")
-        
-        # otherwise, if the areatype is local set the quintile to "Local" by default
-      } else if (geo_selections()$areatype != "Scotland"){
-        updateRadioButtons(session, "quint_type", selected = "Local")
-        
-        if(selected_indicator() %in% c("Mortality amenable to healthcare",
+      available_quints <- simd_data() |>
+        filter(indicator == selected_indicator() & areatype == geo_selections()$areatype & areaname == geo_selections()$areaname) |>
+        select(quint_type) %>%
+        unique()
+
+      # If Scotland is selected, only scotland-level quintiles are appropriate (disable the radio buttons)
+      # If another geography is selected but local-level quintiles aren't available do the same:
+      if (length(available_quints)==1 & "sc_quin" %in% available_quints){
+          updateRadioButtons(session, "quint_type", selected = "Scotland")
+          shinyjs::disable("quint_type")
+
+      # otherwise, if the areatype is local set the quintile to "Local" by default
+            } else if (geo_selections()$areatype != "Scotland"){
+              updateRadioButtons(session, "quint_type", selected = "Local")
+              
+              if(selected_indicator() %in% c("Mortality amenable to healthcare",
                                        "Repeat emergency hospitalisation in the same year",
                                        "Preventable emergency hospitalisation for a chronic condition",
                                        "Life expectancy, females",
                                        "Life expectancy, males")) {
-          
-          shinyjs::disable("quint_type")
-        } else {
-          shinyjs::enable("quint_type")
-        }
-      }
-      
-    })
+                
+                shinyjs::disable("quint_type")
+                } else {
+                  shinyjs::enable("quint_type")
+                } 
+              }
+      })
     
     
     #######################################################.

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -216,24 +216,26 @@ function(input, output, session) {
   # run the module that creates the server logic for the summary tab, unless 'all indicators' is selected as the profile, in which case hide the tab
   observe({
     req(input$profile_choices != "")
-    if (input$profile_choices != "All Indicators" & input$profile_choices != "Care and Wellbeing" & input$profile_choices != "Mental Health") {
-      nav_show("sub_tabs", target = "summary_tab")
-      summary_table_server("summary", geo_selections, reactive({input$profile_choices}), areatype_data)
     
-      } else if(input$profile_choices == "Care and Wellbeing"){
-        
+    if (input$profile_choices == "All Indicators"){ # if all indicators selected then hide the summary view
+      nav_hide("sub_tabs", target = "summary_tab")
+      
+    } else if(input$profile_choices == "Care and Wellbeing"){ #supply CWB specific profile domain ordering
+      
       nav_show("sub_tabs", target = "summary_tab")
       summary_table_server("summary", geo_selections, reactive({input$profile_choices}), areatype_data, domain_order = c("Over-arching indicators","Early years","Education","Work","Living standards",
                                                                                                                          "Healthy places", "Impact of ill health prevention","Discrimination and racism"))
-      } else if(input$profile_choices == "Mental Health"){
-        
-        nav_show("sub_tabs", target = "summary_tab")
-        summary_table_server("summary", geo_selections, reactive({input$profile_choices}), areatype_data, domain_order = c("Mental health outcomes", "Individual determinants",
-                                                                                                                           "Community determinants", "Structural determinants"))
-        } else {
+    } else if(input$profile_choices == "Mental Health"){ #supply mental health specific profile domain ordering
       
-      nav_hide("sub_tabs", target = "summary_tab")
+      nav_show("sub_tabs", target = "summary_tab")
+      summary_table_server("summary", geo_selections, reactive({input$profile_choices}), areatype_data, domain_order = c("Mental health outcomes", "Individual determinants",
+                                                                                                                         "Community determinants", "Structural determinants"))
+    } else { # all other profiles run the summary tab but no need to supply domain order and they will sort alphabetically
+      nav_show("sub_tabs", target = "summary_tab")
+      summary_table_server("summary", geo_selections, reactive({input$profile_choices}), areatype_data)
+      
     }
+    
   })
   
   

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -166,7 +166,7 @@ function(input, output, session) {
   ###############################################################
   
   # run the module containing server logic for the trends tab - this is visible for every single profile 
-  trend_mod_server("trends", profile_data, geo_selections)
+  trend_mod_server("trends", profile_data, geo_selections, reactive({input$profile_choices}))
   
   
   # run the module containing server logic for the  rank tab - this is visible for every single profile

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -176,7 +176,7 @@ function(input, output, session) {
   # run the module containing the server logic for the  deprivation tab ONLY when specific profiles are selected, otherwise hide the tab
   observe({
     req(input$profile_choices != "")
-    if (profiles_list[[input$profile_choices]] %in% c("CWB", "HWB", "POP", "CYP") & !is.null(profiles_list[[input$profile_choices]])) {
+    if (profiles_list[[input$profile_choices]] %in% c("CWB", "HWB", "POP", "CYP", "MEN") & !is.null(profiles_list[[input$profile_choices]])) {
       nav_show("sub_tabs", target = "simd_tab")
       simd_navpanel_server("simd", simd_data, geo_selections)
       
@@ -216,7 +216,7 @@ function(input, output, session) {
   # run the module that creates the server logic for the summary tab, unless 'all indicators' is selected as the profile, in which case hide the tab
   observe({
     req(input$profile_choices != "")
-    if (input$profile_choices != "All Indicators" & input$profile_choices != "Care and Wellbeing") {
+    if (input$profile_choices != "All Indicators" & input$profile_choices != "Care and Wellbeing" & input$profile_choices != "Mental Health") {
       nav_show("sub_tabs", target = "summary_tab")
       summary_table_server("summary", geo_selections, reactive({input$profile_choices}), areatype_data)
     
@@ -225,7 +225,12 @@ function(input, output, session) {
       nav_show("sub_tabs", target = "summary_tab")
       summary_table_server("summary", geo_selections, reactive({input$profile_choices}), areatype_data, domain_order = c("Over-arching indicators","Early years","Education","Work","Living standards",
                                                                                                                          "Healthy places", "Impact of ill health prevention","Discrimination and racism"))
-    } else {
+      } else if(input$profile_choices == "Mental Health"){
+        
+        nav_show("sub_tabs", target = "summary_tab")
+        summary_table_server("summary", geo_selections, reactive({input$profile_choices}), areatype_data, domain_order = c("Mental health outcomes", "Individual determinants",
+                                                                                                                           "Community determinants", "Structural determinants"))
+        } else {
       
       nav_hide("sub_tabs", target = "summary_tab")
     }
@@ -302,7 +307,7 @@ function(input, output, session) {
   # filters the deprivation dataset by selected profile, filtered data then passed to the depriavtion visualisation module 
   simd_data <- reactive({
     
-    req(profiles_list[[input$profile_choices]] %in% c("HWB", "CWB", "POP", "CYP")) # only run when specific profiles have been selected
+    req(profiles_list[[input$profile_choices]] %in% c("HWB", "CWB", "POP", "CYP", "MEN")) # only run when specific profiles have been selected
 
     dt <- setDT(simd_dataset) # set to class data.table
 

--- a/shiny_app/ui.R
+++ b/shiny_app/ui.R
@@ -56,7 +56,7 @@ page_navbar(
                            layout_columns(
                              profile_homepage_btn_modUI(id = "alc_nav", profile_name = "Alcohol", description = markdown("View indicators relating to **Community safety**, **Environment**, **Health**, **Prevalence** and **Services**.")),
                              profile_homepage_btn_modUI(id = "drg_nav", profile_name = "Drugs", description = markdown("View indicators relating to **Community safety**, **Environment**, **Health**, **Prevalence** and **Services**.")),
-                             profile_homepage_btn_modUI(id = "men_nav", profile_name = "Mental Health", description = markdown("View indicators relating to **adult mental health**, for both males and females."))
+                             profile_homepage_btn_modUI(id = "men_nav", profile_name = "Mental Health", description = markdown("View indicators relating to **Mental health outcomes**, and **Individual**, **Community** and **Structural determinants**  for adults. Forthcoming in 2025: indicators for children and young people."))
                            ),
                            
                            layout_columns(

--- a/shiny_app/ui.R
+++ b/shiny_app/ui.R
@@ -99,6 +99,21 @@ page_navbar(
                 ),
               # hidden geography filterers to display when button clicked
                 hidden(div(id = "geo_filters_hidden",
+                
+                           # notice to display to users if they select police divisions as they are only 
+                           # available for some indicators within the mental health profile.
+                           conditionalPanel(condition = "input.areatype == 'Police division'",
+                                            br(),
+                                            layout_columns(
+                                              col_widths = c(8, -4),
+                                              card(
+                                                card_header(bs_icon("info-circle-fill", size = "1.2em"),"Police divisions",class = "info-box-header"),
+                                                card_body("Please note that data split by police division is currently only available for a small subset of indicators within the mental health profile.")
+                                              )
+                                            )
+                           ),         
+                           
+                           
                   layout_columns(widths = c(4, 4, 2),fillable = FALSE,
                     # area type filter 
                     selectizeInput("areatype", "Area type:", choices = areatype_list, selected = "Scotland"),


### PR DESCRIPTION
PR includes:
1. Adding police divisions as an available geography (+ adding a filter)
2. Ensuring mental health profile has a deprivation tab (popgroups tab added in a recent PR)
3. Updating the text on the home page button
4. Making code to disable the quintile radio buttons more widely applicable to any indicator without a local-level quintile
5. Fixing axis error previously introduced by ER when fixing the popgroup trend chart x-axis label order issue.