### PR TITLE
ER Adding domain names to the indicator filter

### DIFF
--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -90,7 +90,7 @@ profiles_list <- list(
   "Tobacco" = "TOB",
   "Mental Health" = "MEN",
   "All Indicators" = "ALL"
-  )
+)
 
 # archived indicators - for removing from the summary tab and separating indicators 
 # into 'active' and 'archived' in the indicator filters across the other tabs
@@ -121,7 +121,15 @@ areatype_list <- c("Alcohol & drug partnership",
 
 rank_area_comparators_list <- geo_lookup$areaname[geo_lookup$areatype %in% c("HSC partnership", "Scotland", "Health board")]
 
-
+# domain orders
+CWB_domain_order <- c("Over-arching indicators","Early years","Education","Work","Living standards",
+                      "Healthy places", "Impact of ill health prevention","Discrimination and racism")
+MEN_domain_order <- c("Mental health outcomes", "Individual determinants",
+                      "Community determinants", "Structural determinants",
+                      "Male adult", "Female adult" # to be dropped once indicators reassigned elsewhere/archived
+)
+CYP_domain_order <- c("Safe", "Healthy", "Achieving", "Nurtured", "Active", "Respected", "Responsible", "Included"
+)
 
 # 5. Dashboard theme ---------------------------------------------------------------
 
@@ -154,7 +162,7 @@ phs_theme <- bs_theme(version = 5, # bootstrap version 5
       ".global-filter {background-color: #ECECEC; color: black; padding: 5px;}", # make global filter buttons grey
       ".btn-apply-geo-filter {margin-top:20px; background-color: orange; font-weight: bold; border: none; border-radius: 0;}",
       ".chart-controls-icon {background-color:#0078D4; color:white; border-radius:5em; padding:5px;}" # styling of the chart controls icon
-
+      
     )
   )
 
@@ -170,4 +178,4 @@ chart_controls_icon <- function(size = "2em") {
 }
 
 
-  
+

--- a/shiny_app/modules/filters/indicator_filter_mod.R
+++ b/shiny_app/modules/filters/indicator_filter_mod.R
@@ -7,18 +7,18 @@
 # id = unique id 
 indicator_filter_mod_ui <- function(id, label = "Select indicator") {
   ns <- NS(id) # namespace
-
+  
   selectizeInput(ns("indicator_filter"), label = label, choices = NULL, multiple = FALSE)
-
+  
 }
 
 # server function
 # id = unique id
 # filtered_data = reactive df which determines available choices for the filter 
-indicator_filter_mod_server <- function(id, filtered_data, geo_selections) {
+indicator_filter_mod_server <- function(id, filtered_data, geo_selections, domain_order = NULL) {
   moduleServer(id, function(input, output, session) {
     
-
+    
     # update indicator choices
     observe({
       
@@ -27,18 +27,39 @@ indicator_filter_mod_server <- function(id, filtered_data, geo_selections) {
       # filter data by selected geography to get available indicators for selected profile
       all <- all[areatype == geo_selections()$areatype & areaname == geo_selections()$areaname]
       
+      # get lists of active indicators grouped by domain (and sorted: either alphabetically, or by specified domain_order)
+      all_domains <- sort(unique(all$domain))
       
-      # get list of active indicators
-      active <- unique(all[!(ind_id %in% archived_indicators)]$indicator)
+      if(!is.null(domain_order)) {
+        all_domains <- all_domains[order(match(all_domains, domain_order))]
+      }
       
-      # get list of archived indicators
-      archived <- unique(all[ind_id %in% archived_indicators]$indicator)
+      ind_list <- list()
       
-      # populate the indicator filter with indicator choices - grouping choices into active and archived
-      updateSelectizeInput(session, "indicator_filter", choices = list(`Active indicators` = as.list(active),
-                                                                       `Archived indicators` = as.list(archived)))
-
-
+      # Subset the indicators by domain, sort them, and add to the ind_list (which becomes a list of lists)
+      for (i in all_domains) {
+        # single item lists were being treated differently in the drop down, hence this logic
+        if (length(unique(all[!(ind_id %in% archived_indicators) & (domain == i)]$indicator)) > 1) { 
+          ind_list[[i]] <- sort(unique(all[!(ind_id %in% archived_indicators) & (domain == i)]$indicator))
+        } else if (length(unique(all[!(ind_id %in% archived_indicators) & (domain == i)]$indicator)) == 1){
+          ind_list[[i]] <- list(sort(unique(all[!(ind_id %in% archived_indicators) & (domain == i)]$indicator)))
+        }
+      }
+      # Add the archived indicators
+      # single item lists were being treated differently in the drop down, hence this logic
+      if (length(unique(all[(ind_id %in% archived_indicators)]$indicator)) > 1) {
+        ind_list[["Archived"]] <- sort(unique(all[(ind_id %in% archived_indicators)]$indicator))
+      } else if (length(unique(all[(ind_id %in% archived_indicators)]$indicator)) == 1) {
+        ind_list[["Archived"]] <- list(sort(unique(all[(ind_id %in% archived_indicators)]$indicator)))
+      }
+      
+      
+      # populate the indicator filter with indicator choices - grouping choices into domains, then archived at the end
+      updateSelectizeInput(session, "indicator_filter", 
+                           choices = ind_list
+      ) 
+      
+      
     })
     
     

--- a/shiny_app/modules/visualisations/pop_groups_mod.R
+++ b/shiny_app/modules/visualisations/pop_groups_mod.R
@@ -137,7 +137,7 @@ pop_groups_ui <- function(id) {
 #######################################################
 
 
-pop_groups_server <- function(id, dataset, geo_selections) {
+pop_groups_server <- function(id, dataset, geo_selections, domain_order=NULL) {
   moduleServer(id, function(input, output, session) {
     
     
@@ -175,7 +175,7 @@ pop_groups_server <- function(id, dataset, geo_selections) {
     #######################################################
     
     # generate list of indicators (from the simd indicators dataset) available 
-    selected_indicator <- indicator_filter_mod_server(id = "indicator_filter", dataset, geo_selections)
+    selected_indicator <- indicator_filter_mod_server(id = "indicator_filter", dataset, geo_selections, domain_order)
 
     
     # creates trend data

--- a/shiny_app/modules/visualisations/rank_charts_mod.R
+++ b/shiny_app/modules/visualisations/rank_charts_mod.R
@@ -143,7 +143,7 @@ rank_mod_ui <- function(id) {
 # id = unique id 
 # profile_data = reactive df in main server
 # geo_selections <- reactive values in main server storing global geography selections
-rank_mod_server <- function(id, profile_data, geo_selections) {
+rank_mod_server <- function(id, profile_data, geo_selections, domain_order=NULL) {
   moduleServer(id, function(input, output, session) {
     
 
@@ -188,7 +188,7 @@ rank_mod_server <- function(id, profile_data, geo_selections) {
     # stores selected indicator ----------------------------------------------
     # (note this is a module )
     selected_indicator <- indicator_filter_mod_server(id = "indicator_filter", 
-                                                      profile_data, geo_selections)
+                                                      profile_data, geo_selections, domain_order)
     
 
     

--- a/shiny_app/modules/visualisations/simd_mod.R
+++ b/shiny_app/modules/visualisations/simd_mod.R
@@ -146,7 +146,7 @@ simd_navpanel_ui <- function(id) {
 ## MODULE SERVER
 #######################################################.
 
-simd_navpanel_server <- function(id, simd_data, geo_selections){
+simd_navpanel_server <- function(id, simd_data, geo_selections, domain_order=NULL){
   moduleServer(id, function(input, output, session) {
     
     # permits compatibility between shiny and cicerone tours
@@ -203,7 +203,7 @@ simd_navpanel_server <- function(id, simd_data, geo_selections){
     #######################################################.
     
     # generate list of indicators (from the simd indicators dataset) available 
-    selected_indicator <- indicator_filter_mod_server(id="simd_indicator_filter", simd_data, geo_selections)
+    selected_indicator <- indicator_filter_mod_server(id="simd_indicator_filter", simd_data, geo_selections, domain_order)
     
     
     geography_data <- reactive({

--- a/shiny_app/modules/visualisations/trend_mod.R
+++ b/shiny_app/modules/visualisations/trend_mod.R
@@ -127,7 +127,7 @@ trend_mod_ui <- function(id) {
 ## MODULE SERVER
 #######################################################
 
-trend_mod_server <- function(id, filtered_data, geo_selections) {
+trend_mod_server <- function(id, filtered_data, geo_selections, domain_order=NULL) {
   moduleServer(id, function(input, output, session) {
     
     # permits compatibility between shiny and cicerone tours
@@ -354,7 +354,8 @@ trend_mod_server <- function(id, filtered_data, geo_selections) {
     
     selected_indicator <- indicator_filter_mod_server("trend_indicator_filter",
                                                       filtered_data,
-                                                      geo_selections)
+                                                      geo_selections, 
+                                                      domain_order)
     
     # create reactive data - filtering by selected indicator
     indicator_filtered_data <- reactive({

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -325,6 +325,18 @@ function(input, output, session) {
   # REACTIVE DATASETS
   ###################################################
   
+  # function to create a domain column - this ensures we return the correct domain for the chosen profile in cases where an indicator
+  # is assigned to more than one profile (and therefore more than one domain)
+   add_domain_col <- function(dataset) {
+    dataset <- dataset[, domain := fifelse(substr(profile_domain1, 1, 3) == profiles_list[[input$profile_choices]],
+                                 substr(profile_domain1, 5, nchar(as.vector(profile_domain1))),
+                                 fifelse(substr(profile_domain2, 1, 3) == profiles_list[[input$profile_choices]],
+                                         substr(profile_domain2, 5, nchar(as.vector(profile_domain2))),
+                                         substr(profile_domain3, 5, nchar(as.vector(profile_domain3)))))]
+    dataset
+    
+  }
+  
   # 1. MAIN DATASET FILTERED BY PROFILE
   # searches for the abbreviated name of the selected profile across the 3 profile columns in the main dataset
   # note: there are 3 profile columns because some indicators belong to more than 1 profile 
@@ -344,13 +356,8 @@ function(input, output, session) {
                  substr(profile_domain2, 1, 3) == profiles_list[[input$profile_choices]] |
                  substr(profile_domain3, 1, 3) == profiles_list[[input$profile_choices]]]
       
-      # create a domain column - this ensures we return the correct domain for the chosen profile in cases where an indicator
-      # is assigned to more than one profile (and therefore more than one domain)
-      dt <- dt[, domain := fifelse(substr(profile_domain1, 1, 3) == profiles_list[[input$profile_choices]],
-                                   substr(profile_domain1, 5, nchar(as.vector(profile_domain1))),
-                                   fifelse(substr(profile_domain2, 1, 3) == profiles_list[[input$profile_choices]],
-                                           substr(profile_domain2, 5, nchar(as.vector(profile_domain2))),
-                                           substr(profile_domain3, 5, nchar(as.vector(profile_domain3)))))]
+      dt <- add_domain_col(dt)
+      
     }
   })
   
@@ -383,13 +390,7 @@ function(input, output, session) {
                substr(profile_domain2, 1, 3) == profiles_list[[input$profile_choices]] |
                substr(profile_domain3, 1, 3) == profiles_list[[input$profile_choices]]]
     
-    # create a domain column - this ensures we return the correct domain for the chosen profile in cases where an indicator
-    # is assigned to more than one profile (and therefore more than one domain)
-    dt <- dt[, domain := fifelse(substr(profile_domain1, 1, 3) == profiles_list[[input$profile_choices]],
-                                 substr(profile_domain1, 5, nchar(as.vector(profile_domain1))),
-                                 fifelse(substr(profile_domain2, 1, 3) == profiles_list[[input$profile_choices]],
-                                         substr(profile_domain2, 5, nchar(as.vector(profile_domain2))),
-                                         substr(profile_domain3, 5, nchar(as.vector(profile_domain3)))))]
+    dt <- add_domain_col(dt)
     
   })
   
@@ -411,13 +412,7 @@ function(input, output, session) {
                substr(profile_domain2, 1, 3) == profiles_list[[input$profile_choices]] |
                substr(profile_domain3, 1, 3) == profiles_list[[input$profile_choices]]]
     
-    # create a domain column - this ensures we return the correct domain for the chosen profile in cases where an indicator
-    # is assigned to more than one profile (and therefore more than one domain)
-    dt <- dt[, domain := fifelse(substr(profile_domain1, 1, 3) == profiles_list[[input$profile_choices]],
-                                 substr(profile_domain1, 5, nchar(as.vector(profile_domain1))),
-                                 fifelse(substr(profile_domain2, 1, 3) == profiles_list[[input$profile_choices]],
-                                         substr(profile_domain2, 5, nchar(as.vector(profile_domain2))),
-                                         substr(profile_domain3, 5, nchar(as.vector(profile_domain3)))))]
+    dt <- add_domain_col(dt)
     
     
   })


### PR DESCRIPTION
Particularly useful for profiles with lots of indicators: here the indicators are sorted and grouped into sublists based on their domain, which is added as a (non-selectable) subtitle in the dropdown menu. The domain_order is applied if specified. I've added domain ordering for CYP to match the SHANARRI ordering. There is definite room for simplification of this code, but it works!