### PR TITLE
ER Adding a conditional header line for the mental health profile

### DIFF
--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -109,8 +109,12 @@ function(input, output, session) {
     tags$h1("Profile:", input$profile_choices, class = "profile-header")
   })
   
+  # 2. header showing choices for mental health profile (conditional on this profile being selected)
+  output$mhprofile_header <- renderUI({
+    tags$h1("Age group:", input$mhprofile_choices, class = "profile-header")
+  })
   
-  # 2. header showing selected areatype and areaname
+  # 3. header showing selected areatype and areaname
   output$geography_header <- renderUI({
     
     if(geo_selections()$areatype == "Scotland") {
@@ -144,19 +148,27 @@ function(input, output, session) {
     hide("prof_filter_hidden")
   })
   
-  
   # when a user clicks the 'change area' filter, toggle the hidden geography filters to make them visible
   observeEvent(input$show_geo_filters, {
     toggle("geo_filters_hidden")
   })
-  
   
   # once a user has clicked the button to updated their geography choices, hide the filter again 
   observeEvent(input$apply_geo_filters, {
     hide("geo_filters_hidden")
   })
   
+   # when a user clicks the 'change age group' filter (mental health only), toggle the hidden filter to make it visible
+  observeEvent(input$show_mhprofile_filter, {
+    toggle("mhprof_filter_hidden")
+  })
   
+  # once a user has updated their choice in the filter, hide the filter again 
+  observeEvent(input$mhprofile_choices, {
+    hide("mhprof_filter_hidden")
+  })
+  
+ 
   
   
   

--- a/shiny_app/ui.R
+++ b/shiny_app/ui.R
@@ -92,6 +92,22 @@ page_navbar(
                                      choices = names(profiles_list),  
                                      options = list(onInitialize = I('function() { this.setValue(""); }')))
                     )),
+  
+            # Conditional Mental Health profile header with button
+            conditionalPanel(condition = "input.profile_choices == 'Mental Health'", 
+              div(class = "header-elements",
+                  uiOutput("mhprofile_header"),
+                  shiny::actionLink(inputId = "show_mhprofile_filter", label = "Change age group", icon = icon("filter"), class = "global-filter")
+              ),
+              # hidden profile filter to display when button clicked 
+              hidden(div(id = "mhprof_filter_hidden",
+                         selectizeInput(inputId = "mhprofile_choices", 
+                                        label = "", 
+                                        choices = c("Adults", "Children and Young People"),  
+                                        selected = "Adults")
+              ))
+            ), #close conditional panel
+  
               # geography header with button
                 div(class = "header-elements",
                   uiOutput("geography_header"),
@@ -113,6 +129,8 @@ page_navbar(
                     actionButton("apply_geo_filters", label = "Apply geography filters", class = "btn-apply-geo-filter")
                     ) # close layout columns
                   )), # close hidden div
+
+  
              br(), # add space between header and sub-tabs
 
   


### PR DESCRIPTION
Users can choose between Adult and CYP mental health profiles, if the selected profile is mental health. It works but currently does nothing: waiting for previous changes to server.R to be merged to main, then will add some logic based on the result of the selection. (Note to self: use domain == "MEN-CYP Mental Health" for now, though this is likely to change when the CYP indicators are added, with their domains. Also add an 'indicator set in development' banner to the landing page if the CYP mental health profile is selected). 