### PR TITLE
ER Combining deprivation and popgroup tabs

### DIFF
--- a/data_preparation/changes_to_popgroup.R
+++ b/data_preparation/changes_to_popgroup.R
@@ -1,18 +1,55 @@
 # processing the popgroup data file for new tab.
 
 
+popgroup_dataset_new <- read_parquet("/conf/MHI_Data/Liz/repos/scotpho-profiles-app/shiny_app/data/popgroup_dataset_new")  # dataset behind popgroup panel
+# new data format:
+# split_name is the same: this populates the first split filter "Select population split"
+# split_names have been standardised throughout. 
+# Current options: "Age", "Income (Equivalised)", "Long-term conditions", "Sex", "Deprivation (SIMD)", "Urban/Rural". 
+# Any rows with split_name=="Total" should be dropped.
+# Deprivation should always be in split_name rather than split_value2, because its data needs to be treated differently.
+# This means the other splits can be in both columns, depending on whether also combined with SIMD or not.
 
-popgroup_dataset <- read_parquet("data/popgroup_dataset") # dataset behind popgroup panel
+# split_value2 = new variable, populates the second split filter "Select 2nd population split:"
+# Current values for split_value2 are "Male", "Female", "Total". 
+# split_value2 should be NA if the data relate to a single split
 
-popgroup_dataset2 <- read_parquet("data/popgroup_dataset2") # dataset behind popgroup panel
+# split_values are what are displayed in the charts, and require some format standardising:
+# ages e.g., "0 to 4 years", "60+ years", "Children", "Working-age adults", "Pensioners" (latter 3 could do with age ranges being given too) (All)
+# income: "1 - highest income" to "5 - lowest income"
+# Long-term conditions: "No", "Yes, but not limiting", "Yes, limiting"
+# Sex: Female, Male, Total (All)
+# SIMD: "1 - most deprived" to "5 - least deprived" (Total also given)
+# Urb/Rural: "1 Large urban areas" to "6 Remote rural"
+# split_value == "Total" is what is used to plot the average on the charts, if selected. 
+# split_value == "Total" will currently need to be repeated in the data for each split_name (and split2_filter, if used), unless this can be included in the data prep
+# I have extracted Totals for each year x code x ind_id without a split_value==Total (from main_dataset) and appended to the popgroup data to give averages.
+# In some cases in CWB profile this has introduced an issue as the Scotland wide and the popgroup data have different def_periods:
+# e.g., food insecurity has national data for 4 years aggregated (e.g., 2016-2019) while SIMD data are annual. 
+# Even though the aggregated data will have a numeric 'year' value that matches an annual value they should not be plotted together, as this would be misleading.
+
+# quint_type has been assumed to be scotland unless specified. 
+# Check this assumption is correct. Applies to HWB and CWB profiles only (when SIMD data were included in the popgroups file)
 
 
+# Original popgroup dataset: n = 26,563 
+popgroup_dataset <- read_parquet("/conf/MHI_Data/Liz/repos/scotpho-profiles-app/shiny_app/data/popgroup_dataset") # dataset behind popgroup panel
+
+
+# popgroup_dataset2 <- read_parquet("/conf/MHI_Data/Liz/repos/scotpho-profiles-app/shiny_app/data/popgroup_dataset2") # dataset behind popgroup panel
+# #15955
+
+
+# Original SIMD file: n = 258,329
+simd_dataset2 <- read_parquet("/conf/MHI_Data/Liz/repos/scotpho-profiles-app/shiny_app/data/deprivation_dataset")
+# sex included, NA for most
 
 # The main popgroups dataset doesn't have a 'total' category for SIMD: will this be a problem?
+# No, but won't show 'average' line unless total is given. Can extract from main dataset
 # standardise the splits:
 popgroup_dataset_std <- popgroup_dataset %>%
   mutate(split_name = case_when(split_name=="Gender" ~ "Sex", # some also have split_name == Total when split_value==All: how to use?
-                                split_name=="Scottish Index of Multiple Deprivation" ~ "SIMD",
+                                split_name %in% c("Scottish Index of Multiple Deprivation", "SIMD") ~ "Deprivation (SIMD)",
                                 split_name %in% c("Long-term physical/mental health condition", "Longterm conditions") ~ "Long-term conditions",
                                 split_name=="Equivalised income" ~ "Income (Equivalised)",
                                 TRUE ~ split_name)) %>%
@@ -27,47 +64,100 @@ popgroup_dataset_std <- popgroup_dataset %>%
                                  split_value=="4th" ~ "4",
                                  split_value=="5th-Least deprived" ~ "5 - least deprived",
                                  split_value=="5 - most deprived" ~ "5 - least deprived", # checked the data to confirm this was coded wrong
-                                 split_value=="All sexes" ~ "All",
+                                 split_value=="All sexes" ~ "Total",
                                  split_value=="Males" ~ "Male",
                                  split_value=="Females" ~ "Female",
                                  split_name=="Long-term conditions" & split_value %in% c("Limiting long-term conditions", "Limiting long-term illness") ~ "Yes, limiting",
                                  split_name=="Long-term conditions" & split_value %in% c("Non-limiting long-term conditions", "Non-limiting long-term illness") ~ "Yes, but not limiting",
                                  split_name=="Long-term conditions" & split_value %in% c("No long-term conditions", "No long-term illness") ~ "No",
-                                 split_value=="Working to age adults" ~ "Working age adults",
-                                 split_value=="All ages" ~ "All",
+                                 split_value %in% c("Working to age adults", "Working age adults") ~ "Working-age adults",
+                                 split_value %in% c("All ages", "All") ~ "Total",
                                  split_name=="Age" ~ gsub("-", " to ", split_value),
                                  TRUE ~ split_value)) %>%
   mutate(split_value = case_when(split_name=="Age" ~ gsub("Aged ", "", split_value),
                                  TRUE ~ split_value)) %>%
   mutate(split_value = case_when(split_name=="Age" & grepl("^[0-9]", split_value)==TRUE ~ paste0(split_value, " years"), 
                                  TRUE ~ split_value)) %>%
-  mutate(split_value2 = case_when(split_name == "SIMD" ~ "Total", # i.e., all sexes
-                                  TRUE ~ as.character(NA)))
+  mutate(split_value2 = case_when(split_name == "Deprivation (SIMD)" ~ "Total", # i.e., all sexes
+                                  TRUE ~ as.character(NA))) %>%
+  mutate(quint_type = case_when(split_name == "Deprivation (SIMD)" ~ "sc_quin", # an assumption: check
+                                  TRUE ~ as.character(NA))) %>%
+  filter(!split_name=="Total") #%>%
+ # filter(!ind_id %in% c(30000:39999)) # remove original MHI data, as adding in more complete set (with SIMD x sex)
+#check what splits are now used:
 popgroups_dataset_std_split <- popgroup_dataset_std %>% # 
   select(split_value, split_value2, 
          split_name) %>%
   unique()        
 
+# find which popgroup splits don't have total
+popgp_have_total <- popgroup_dataset_std %>%
+  mutate(total_exists = ifelse(split_value=="Total", 1, 0)) %>%
+  group_by(year, code, ind_id, def_period, split_name) %>%
+  summarise(has_total = sum(total_exists)) %>%
+  ungroup()
+table(popgp_have_total$has_total)
+#0    1     
+#7379 2753    
 
-#flip the columns in the 2nd dataset, so SIMD coding is always first, and sex is 2nd if available
-popgroup_dataset2_std <- popgroup_dataset2 %>%
-  mutate(split_value2 = case_when(split_name=="Sex" ~ split_value,
-                                  TRUE ~ split_value2)) %>%
-  mutate(split_value = case_when(split_name=="Sex" ~ as.character(NA),
-                                 TRUE ~ split_value)) %>%
-  mutate(split_name = case_when(split_name=="Sex + SIMD" ~ "SIMD",
-                                TRUE ~ split_name)) %>%
-  mutate(temp = split_value,
-         split_value = split_value2,
-         split_value2 = temp) %>%
-  select(-temp)
+# get totals for those with 0 total data:
+no_totals <- popgp_have_total %>% # n=7377
+  filter(has_total==0) %>%
+  select(-has_total)
 
-popgroup_dataset_new <- bind_rows(popgroup_dataset2_std, popgroup_dataset_std) #42 vars
+totals <- read_parquet("/conf/MHI_Data/Liz/repos/scotpho-profiles-app/shiny_app/data/main_dataset") %>% # main dataset 
+  merge(y=no_totals, by=c("year", "def_period", "code", "ind_id"), all.y=T)
+#some dat with splits have no totals:
+ind_w_no_totals <- totals %>% #n=204
+  filter(is.na(indicator))
+
+table(ind_w_no_totals$ind_id)
+# 30057 99105 99106 99107 99108 99109 99116 99117 99118 99121 99123 
+# 2    12    42    10    42    28     8     6    10    12    32 
+# 10 CWB indicators: 99105-109, 99116-118, 99121, 99123 and 1 MHI: 30057 (violent crime, because SCJS pooled some years for police div estimates)
+
+
+# prep the total rows for appending to the rest of the data
+totals_4_popgroup_data <- totals %>%
+  filter(!is.na(indicator)) %>%
+  mutate(split_value="Total",
+         split_value2=ifelse(split_name=="Deprivation (SIMD)", "Total", as.character(NA)),
+         quint_type = ifelse(split_name=="Deprivation (SIMD)", "sc_quin", as.character(NA))) # all missing quint_types assumed to be sc_quin
+
+# Existing SIMD file:
+simd_dataset2 <- read_parquet("/conf/MHI_Data/Liz/repos/scotpho-profiles-app/shiny_app/data/deprivation_dataset") %>% # dataset behind simd panel
+  mutate(split_value2=case_when(sex=="Male" ~ "Male",
+                                sex=="Female" ~ "Female",
+                                sex=="Total" ~ "Total",
+                                is.na(sex) ~ "Total"),
+       #  quint_type = case_when(is.na(quint_type) ~ "sc_quin", # all have quint_type
+       #                         TRUE ~ quint_type),
+         split_name = "Deprivation (SIMD)") %>%
+  rename(split_value = quintile) 
+
+# find which simd splits don't have total
+have_total <- read_parquet("/conf/MHI_Data/Liz/repos/scotpho-profiles-app/shiny_app/data/deprivation_dataset") %>%
+  mutate(total_quint = ifelse(quintile=="Total", 1, 0)) %>%
+  group_by(year, def_period, code, ind_id, sex, quint_type) %>%
+  summarise(has_total = sum(total_quint)) %>%
+  ungroup()
+# all SIMD data in the deprivation data has quintile==Total
+
+
+#check what splits are now used:
+simd_dataset2_std_split <- simd_dataset2 %>% # 
+  select(split_value, split_value2, 
+         split_name) %>%
+  unique()       
+
+
+popgroup_dataset_new <- bind_rows(popgroup_dataset_std, totals_4_popgroup_data, simd_dataset2) %>% #42 vars
+  arrange(ind_id, year, code, split_name, split_value, split_value2)
 ## save final file to local repo
 write_parquet(popgroup_dataset_new, "shiny_app/data/popgroup_dataset_new")
 
 # # # what are the splits and names now?
-# popgroup_dataset_new_split <- popgroup_dataset_new %>% # 42 vars
-#   select(split_value, split_value2, split_name) %>%
-#   unique()
+popgroup_dataset_new_split <- popgroup_dataset_new %>% # 42 vars
+  select(split_value, split_value2, split_name) %>%
+  unique()
 # write.csv(popgroup_dataset_new_split, "popgroup_dataset_new_split.csv", row.names=FALSE)

--- a/data_preparation/changes_to_popgroup.R
+++ b/data_preparation/changes_to_popgroup.R
@@ -1,0 +1,73 @@
+# processing the popgroup data file for new tab.
+
+
+
+popgroup_dataset <- read_parquet("data/popgroup_dataset") # dataset behind popgroup panel
+
+popgroup_dataset2 <- read_parquet("data/popgroup_dataset2") # dataset behind popgroup panel
+
+
+
+# The main popgroups dataset doesn't have a 'total' category for SIMD: will this be a problem?
+# standardise the splits:
+popgroup_dataset_std <- popgroup_dataset %>%
+  mutate(split_name = case_when(split_name=="Gender" ~ "Sex", # some also have split_name == Total when split_value==All: how to use?
+                                split_name=="Scottish Index of Multiple Deprivation" ~ "SIMD",
+                                split_name %in% c("Long-term physical/mental health condition", "Longterm conditions") ~ "Long-term conditions",
+                                split_name=="Equivalised income" ~ "Income (Equivalised)",
+                                TRUE ~ split_name)) %>%
+  mutate(split_value = case_when(split_value=="1st-Top quintile" ~ "1 - highest income",
+                                 split_value=="2nd quintile" ~ "2",
+                                 split_value=="3rd quintile" ~ "3",
+                                 split_value=="4th quintile" ~ "4",
+                                 split_value=="5th-Bottom quintile" ~ "5 - lowest income",
+                                 split_value=="1st-Most deprived" ~ "1 - most deprived",
+                                 split_value=="2nd" ~ "2",
+                                 split_value=="3rd" ~ "3",
+                                 split_value=="4th" ~ "4",
+                                 split_value=="5th-Least deprived" ~ "5 - least deprived",
+                                 split_value=="5 - most deprived" ~ "5 - least deprived", # checked the data to confirm this was coded wrong
+                                 split_value=="All sexes" ~ "All",
+                                 split_value=="Males" ~ "Male",
+                                 split_value=="Females" ~ "Female",
+                                 split_name=="Long-term conditions" & split_value %in% c("Limiting long-term conditions", "Limiting long-term illness") ~ "Yes, limiting",
+                                 split_name=="Long-term conditions" & split_value %in% c("Non-limiting long-term conditions", "Non-limiting long-term illness") ~ "Yes, but not limiting",
+                                 split_name=="Long-term conditions" & split_value %in% c("No long-term conditions", "No long-term illness") ~ "No",
+                                 split_value=="Working to age adults" ~ "Working age adults",
+                                 split_value=="All ages" ~ "All",
+                                 split_name=="Age" ~ gsub("-", " to ", split_value),
+                                 TRUE ~ split_value)) %>%
+  mutate(split_value = case_when(split_name=="Age" ~ gsub("Aged ", "", split_value),
+                                 TRUE ~ split_value)) %>%
+  mutate(split_value = case_when(split_name=="Age" & grepl("^[0-9]", split_value)==TRUE ~ paste0(split_value, " years"), 
+                                 TRUE ~ split_value)) %>%
+  mutate(split_value2 = case_when(split_name == "SIMD" ~ "Total", # i.e., all sexes
+                                  TRUE ~ as.character(NA)))
+popgroups_dataset_std_split <- popgroup_dataset_std %>% # 
+  select(split_value, split_value2, 
+         split_name) %>%
+  unique()        
+
+
+#flip the columns in the 2nd dataset, so SIMD coding is always first, and sex is 2nd if available
+popgroup_dataset2_std <- popgroup_dataset2 %>%
+  mutate(split_value2 = case_when(split_name=="Sex" ~ split_value,
+                                  TRUE ~ split_value2)) %>%
+  mutate(split_value = case_when(split_name=="Sex" ~ as.character(NA),
+                                 TRUE ~ split_value)) %>%
+  mutate(split_name = case_when(split_name=="Sex + SIMD" ~ "SIMD",
+                                TRUE ~ split_name)) %>%
+  mutate(temp = split_value,
+         split_value = split_value2,
+         split_value2 = temp) %>%
+  select(-temp)
+
+popgroup_dataset_new <- bind_rows(popgroup_dataset2_std, popgroup_dataset_std) #42 vars
+## save final file to local repo
+write_parquet(popgroup_dataset_new, "shiny_app/data/popgroup_dataset_new")
+
+# # # what are the splits and names now?
+# popgroup_dataset_new_split <- popgroup_dataset_new %>% # 42 vars
+#   select(split_value, split_value2, split_name) %>%
+#   unique()
+# write.csv(popgroup_dataset_new_split, "popgroup_dataset_new_split.csv", row.names=FALSE)

--- a/data_preparation/update_deprivation_data.R
+++ b/data_preparation/update_deprivation_data.R
@@ -58,7 +58,7 @@ update_deprivation_data <- function(load_test_indicators = FALSE, create_backup 
   
   ## create new fields ----
   deprivation_dataset <- deprivation_dataset |>
-    group_by(ind_id, year, quint_type, code) |>
+    group_by(ind_id, year, quint_type, code, sex) |>
     # label if par, sii or rii  positive or negative (helps with health inequality dynamic summary text)
     mutate(across(c(sii, rii, par),
              ~ case_when(. > 0 ~ "positive", . < 0 ~ "negative",  . == 0 ~ "zero"),

--- a/data_preparation/update_popgroup_data_new.R
+++ b/data_preparation/update_popgroup_data_new.R
@@ -1,0 +1,134 @@
+## FUNCTION: update_popgroup_data.R ----
+
+## Creates a single RDS data file within local shiny app data folder that contains latest versions of indicators which populate
+## population group tab in shiny app (ie indicators split by variables such as age/sex/disability etc)
+
+## Caution: a number of these indicators may not have complete information i.e. some are available at Scotland level but not NHS board or LA.
+## Some indicators may cover different time periods for different geography levels e.g. annual figures at Scotland level but rolling year averages for sub national geographies
+## The data preparation script should accept these variances but if issues arise consider if the data structure could be a problem.
+
+## THIS VERSION ACCEPTS COMBINED POPGROUP AND SIMD FILES.
+## INPUT FILE SUFFIX IS _shiny_popgrp_newsplitvals.csv
+## The file has split_value and split_value2 columns. If SIMD + another split is included, the SIMD quintile (including total) is in split_value2.
+## SIMD only data could be split_value = "Total" and split_value2 = SIMD quintile
+## File written out is popgroup_dataset2
+
+## PARAMETERS
+# load_test_indicators : (default is FALSE) option to set to TRUE which reads indicators from the test shiny folder
+# create_backup :  (default is FALSE ) option to set to TRUE when creating a distinct backup version desired e.g. when planning to deploy the app
+
+update_popgroup_data <- function(load_test_indicators = FALSE, create_backup = FALSE) {
+
+  ## Find all separate indicator data files in the shiny data folder -----
+  popgroup_data_files <- list.files(
+    path = shiny_files, 
+    pattern = "*_shiny_popgrp_newsplitvals.csv", 
+    full.names = TRUE
+  )
+  
+  ## Combine into one dataset  -----
+  popgroup_dataset <- combine_files(popgroup_data_files)
+  
+  
+  ## If test indicators are to be included then list files & combine files from test shiny folder
+  if (load_test_indicators == TRUE){
+    
+    ## Find new indicators data files in the test shiny data folder -----
+  test_popgroup_data_files <- list.files(
+      path = test_shiny_files, 
+      pattern = "*_shiny_popgrp_newsplitvals.csv", 
+      full.names = TRUE
+    )
+    
+    
+    ## Combine into one dataset  -----
+    test_popgroup_dataset  <- combine_files(test_popgroup_data_files)
+    
+    ## Combine main dataset and test indicators
+    popgroup_dataset<- bind_rows(popgroup_dataset, test_popgroup_dataset)
+  }
+  
+  
+  ## Attach metadata from the technical doc lookup ----
+  popgroup_dataset <- left_join(x = popgroup_dataset, y = technical_doc, by = "ind_id")
+  
+  # ## Attach geography info from geography lookup--------
+  # popgroup_dataset<- popgroup_dataset |> 
+  #   left_join(geography_lookup, by = "code")
+
+    ## Apply suppression where required ---------
+  popgroup_dataset <- popgroup_dataset |>
+    apply_suppressions()
+  
+  # ## convert some cols to numeric and round digits
+  # popgroup_dataset <- popgroup_dataset |>
+  #   mutate(
+  #     across(
+  #       c("numerator", "measure", "upci", "lowci"),
+  #       ~ round(as.numeric(.), digits = 1)
+  #     )
+  #   )
+  
+  # attach geography info ----
+  popgroup_dataset <- popgroup_dataset |>
+    replace_old_geography_codes(col_name = "code") |>
+    left_join(geography_lookup, by = "code")
+  
+  # formatting numbers ----
+  popgroup_dataset <- popgroup_dataset |>
+    mutate(split_value2 = recode(split_value2, 
+                             "1" = "1 - most deprived", 
+                             "5" = "5 - least deprived")) |>
+    mutate_at(c("numerator", "measure", "lowci", "upci", "rii", "upci_rii",
+                "lowci_rii", "sii", "lowci_sii", "upci_sii", "par", "abs_range",
+                "rel_range", "rii_int", "lowci_rii_int", "upci_rii_int"),round, 1)
+  
+  ## create new fields ----
+  popgroup_dataset <- popgroup_dataset |>
+    group_by(ind_id, year, quint_type, code) |>
+    # label if par, sii or rii  positive or negative (helps with health inequality dynamic summary text)
+    mutate(across(c(sii, rii, par),
+                  ~ case_when(. > 0 ~ "positive", . < 0 ~ "negative",  . == 0 ~ "zero"),
+                  .names = "{.col}_gradient")) |>
+    mutate( # added logic for combos with NA values 
+      qmax = ifelse(sum(is.na(measure))==5, as.character(NA), split_value2[which.max(measure)]), # which quintile contains highest rate/value # NEEDS GENERALISING, IN CASE OTHER DATA PUT IN SPLIT_VALUE2
+      qmin = ifelse(sum(is.na(measure))==5, as.character(NA), split_value2[which.min(measure)]) # which quintile contains lowest rate/value
+    ) |>
+    ungroup() |>
+    rename(indicator = indicator_name)
+  
+  #rename and select columns required for shiny file
+  popgroup_dataset <- popgroup_dataset |>
+ # rename(indicator = indicator_name) |>
+    select(-c(supression, supress_less_than, type_id, file_name, label_inequality))
+  
+  # create a new column which contains the full geography path
+  # most geographies have 2 parts to their path i.e. 'Health Board/NHS Ayrshire & Arran'
+  # with the exception of IZs/HSC Localities where a parent area is also included i.e. 'HSC Locality/Edinburgh City/Edinburgh North-East'
+  popgroup_dataset <- create_geography_path_column(popgroup_dataset)
+  
+  
+  # make available in global environment for viewing what will be sent to shiny app
+  popgroup_dataset <<- popgroup_dataset
+  
+  ## save final file to local repo
+  write_parquet(popgroup_dataset, "shiny_app/data/popgroup_dataset2")
+  
+  ## Optional: Create backup of from local repo -----
+  ## Usually would only want to create a backup if you intend to update live tool
+  ## This file will be stored in backups folder and could be used to roll back app to a particular date
+  if (create_backup == TRUE) {
+    
+    file.copy(
+      "shiny_app/data/popgroup_dataset2", 
+      paste0(backups, "popgroup_dataset2", Sys.Date()), 
+      overwrite = TRUE
+    )
+  } 
+  
+  
+  
+    
+} #close function
+
+#END.

--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -55,7 +55,12 @@ simd_dataset <- read_parquet("data/deprivation_dataset") # dataset behind simd p
 
 techdoc <- read_parquet("data/techdoc") # technical document
 
-popgroup_dataset <- read_parquet("data/popgroup_dataset") # dataset behind popgroup panel
+#popgroup_dataset <- read_parquet("data/popgroup_dataset") # dataset behind popgroup panel
+popgroup_dataset <- read_parquet("data/popgroup_dataset_new") %>% # dataset behind popgroup panel
+  mutate(split_name = case_when(split_name=="SIMD" ~ "Deprivation (SIMD)", # do this in the data prep stage
+                                TRUE ~ split_name)) %>%
+  arrange(ind_id, year, code, split_name, split_value, split_value2)
+
 
 
 # shapefiles (for map) 

--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -55,12 +55,8 @@ simd_dataset <- read_parquet("data/deprivation_dataset") # dataset behind simd p
 
 techdoc <- read_parquet("data/techdoc") # technical document
 
-#popgroup_dataset <- read_parquet("data/popgroup_dataset") # dataset behind popgroup panel
-popgroup_dataset <- read_parquet("data/popgroup_dataset_new") %>% # dataset behind popgroup panel
-  mutate(split_name = case_when(split_name=="SIMD" ~ "Deprivation (SIMD)", # do this in the data prep stage
-                                TRUE ~ split_name)) %>%
-  arrange(ind_id, year, code, split_name, split_value, split_value2)
-
+# popgroup_dataset <- read_parquet("data/popgroup_dataset") # dataset behind popgroup panel
+popgroup_dataset <- read_parquet("data/popgroup_dataset_new") # dataset behind popgroup panel
 
 
 # shapefiles (for map) 

--- a/shiny_app/modules/visualisations/pop_groups_mod.R
+++ b/shiny_app/modules/visualisations/pop_groups_mod.R
@@ -4,6 +4,15 @@
 
 ################################
 
+# to do:
+# quintile buttons and SIMD help only come on if SIMD is an option?
+# remove (Total) from titles if no male/female (could be sex-split indicator already)
+# add totals to all splits, so average can be shown. 
+# check that local quintiles work.
+# fix duplicates in data table
+
+
+
 #######################################################
 ## MODULE UI
 #######################################################
@@ -27,12 +36,27 @@ pop_groups_ui <- function(id) {
                           inputId = ns("split_filter"),
                           label = "Select population split:",
                           selectize = TRUE,
-                          choices = NULL
-                        ),
+                          choices = NULL),
+                        
                         selectizeInput(inputId = ns("split2_filter"), 
                                        label = "Select 2nd population split:", 
-                                       choices = NULL
-                        )
+                                       choices = NULL),
+                        
+                        # filter to include/exclude averages from charts
+                        div(id = ns("deprivation_avg_switch_wrapper"), checkboxInput(ns("average_switch"), label = " include averages",FALSE)),
+                        
+                        # quint type filter 
+                        div(id = ns("deprivation_quintile_type_wrapper"), 
+                            radioButtons(inputId = ns("quint_type"), 
+                                         label = "Quintile Type",
+                                         choices = c("Scotland", "Local"), 
+                                         selected = "Scotland")),
+                        
+                        #guided tour button
+                        actionLink(inputId = ns("deprivation_tour_button"),
+                                   label = "Take a guided tour of this page"),
+                        
+                        actionLink(ns("simd_help"), label = "What is SIMD?", icon = icon("info-circle"))
       ), # close sidebar
       
       
@@ -47,13 +71,15 @@ pop_groups_ui <- function(id) {
         # using the card_footer argument for card() in the meantime and suppressing warnings until bug fixed
         suppressWarnings(
           bslib::navset_card_pill(
+            id = ns("pop_navset_card_pill_barchart"),
             height = 550,
             full_screen = TRUE,
             
             # tab 1: bar chart 
             bslib::nav_panel("Chart",
-                             uiOutput(ns("pop_rank_title")), # title 
-                             highchartOutput(ns("pop_rank_chart"))|> # chart 
+                             value = ns("pop_bar_tab"), #id for guided tour
+                             uiOutput(ns("pop_bar_title")), # title 
+                             highchartOutput(ns("pop_bar_chart"))|> # chart 
                                withSpinner() |> (\(x) {
                                  x[[4]] <- x[[4]] |> bslib::as_fill_carrier() 
                                  x})()
@@ -61,11 +87,13 @@ pop_groups_ui <- function(id) {
             
             # tab 2: data table
             bslib::nav_panel("Table",
-                             reactableOutput(ns("pop_rank_table")) # table
+                             value = ns("pop_bar_data_tab"), #id for guided tour
+                             reactableOutput(ns("pop_bar_table")) # table
             ),
             
             # tab 3: indicator metadata
             bslib::nav_panel("Metadata",
+                             value = ns("pop_metadata_tab"), #id for guided tour
                              metadata_table_mod_UI(ns("indicator_metadata"))
             ),
             
@@ -84,20 +112,22 @@ pop_groups_ui <- function(id) {
             
             # card footer - download buttons
             card_footer(class = "d-flex justify-content-between",
-                        download_chart_mod_ui(ns("save_pop_rankchart")),
-                        download_data_btns_ui(ns("pop_rank_download")))
+                        div(id = ns("deprivation_download_chart"), download_chart_mod_ui(ns("save_pop_barchart"))),
+                        div(id = ns("deprivation_download_data"), download_data_btns_ui(ns("pop_bar_download"))))
           )), # close bar chart card
         
         
-        ######  based on deprivation trend card addeded "pop_" to distinguish the two
+        ######  based on deprivation trend card added "pop_" to distinguish the two
 
         suppressWarnings(
           bslib::navset_card_pill(
+            id = ns("pop_navset_card_pill_linechart"),
             height = 550,
             full_screen = TRUE,
             
             # tab 1: trend chart 
             bslib::nav_panel("Chart",
+                             value = ns("pop_linechart_tab"), #id for guided tour
                              uiOutput(ns("pop_trend_title")), # title
                              highchartOutput(ns("pop_trend_chart")) |> # chart
                                # issue described here: https://github.com/daattali/shinycssloaders/issues/76 
@@ -108,6 +138,7 @@ pop_groups_ui <- function(id) {
             ),
             # tab 2: data table 
             bslib::nav_panel("Table",
+                             value = ns("pop_table_linechart_tab"), #id for guided tour
                              reactableOutput(ns("pop_trend_table"))
             ),
             
@@ -115,17 +146,18 @@ pop_groups_ui <- function(id) {
             
             # extra controls for filters
             bslib::nav_item(
-              bslib::popover(
+              div(id = ns("pop_popover"),
+                  bslib::popover(
                 title = "Filters",
                 chart_controls_icon(),
                 # too many CI for age split, removed at this stage
                 checkboxInput(ns("trend_ci_switch"), label = " include confidence intervals", FALSE) 
               )
-            ),
+            )),
             # card footer - download buttons
             card_footer(class = "d-flex justify-content-between",
-                        download_chart_mod_ui(ns("save_pop_trendchart")),
-                        download_data_btns_ui(ns("pop_trend_download")))
+                        div(id = ns("deprivation_download_chart"), download_chart_mod_ui(ns("save_pop_trendchart"))),
+                        div(id = ns("deprivation_download_data"), download_data_btns_ui(ns("pop_trend_download"))))
           )
         ) # close trend card
       ) # close layout column wrap
@@ -141,8 +173,11 @@ pop_groups_ui <- function(id) {
 #######################################################
 
 
-pop_groups_server <- function(id, dataset, geo_selections) {
+pop_groups_server <- function(id, dataset, geo_selections, selected_profile) {
   moduleServer(id, function(input, output, session) {
+    
+    # permits compatibility between shiny and cicerone tours
+    ns <- session$ns
     
     #######################################################
     ## Dynamic filters -----
@@ -203,7 +238,31 @@ pop_groups_server <- function(id, dataset, geo_selections) {
       }
     })
       
-
+    observe({
+      # if scotland is selected or the selected indicator is patients per GP OR the profile==MEN (not available at local quintiles) 
+      # then set selected quintile to "Scotland" and disable the filter
+      
+      if(geo_selections()$areatype == "Scotland" | selected_indicator() == "Patients per general practitioner" | selected_profile() == "MEN"){
+        updateRadioButtons(session, "quint_type", selected = "Scotland")
+        shinyjs::disable("quint_type")
+        
+        # otherwise, if the areatype is local set the quintile to "Local" by default
+      } else if (geo_selections()$areatype != "Scotland"){
+        updateRadioButtons(session, "quint_type", selected = "Local")
+        
+        if(selected_indicator() %in% c("Mortality amenable to healthcare",
+                                       "Repeat emergency hospitalisation in the same year",
+                                       "Preventable emergency hospitalisation for a chronic condition",
+                                       "Life expectancy, females",
+                                       "Life expectancy, males")) {
+          
+          shinyjs::disable("quint_type")
+        } else {
+          shinyjs::enable("quint_type")
+        }
+      }
+      
+    })
     
     #######################################################
     ## Reactive data / values ----
@@ -228,22 +287,13 @@ pop_groups_server <- function(id, dataset, geo_selections) {
 
       req(popgroup_filtered_data())
       
-      #should be an easier logic, but "if (exists("input$split2_filter"))" wasn't working...
-      available_2nd_splits <- popgroup_filtered_data() %>% # clunky: needs work
-        filter(split_name == input$split_filter & !is.na(split_value2)) %>%
-        select(split_value2) %>%
-        group_by(split_value2) %>%
-        summarise() %>%
-        arrange(desc(split_value2)) %>%  # to give Total first, and then Male and Female if available (could factorise also when more options)
-        pull(split_value2)
-      
-      # If 2nd splits are available, enable split2_filter, otherwise disable it
-      if(length(available_2nd_splits)>0) {
+      # If 2nd splits are available (i.e., only for SIMD currently), filter the data on the selected split2
+      if(input$split_filter == "Deprivation (SIMD)") { #will need generalising if other 1st splits are available
 
       df <- popgroup_filtered_data() %>%
         filter(split_name == input$split_filter) %>% # filter by selected split
         filter(split_value2 == input$split2_filter) %>% # filter by the 2nd split value
-        filter(!split_value == "Total") %>% # when SIMD data has Total row (not sure whether this will be used yet...)
+       # filter(!split_value == "Total") %>% # when SIMD data has Total row (not sure whether this will be used yet...)
         arrange(year, split_value2) 
       
       } else {
@@ -258,30 +308,83 @@ pop_groups_server <- function(id, dataset, geo_selections) {
       
     })
     
+    # Additional trend data filtering and processing required if the split is SIMD:
+    simd_pop_trend_data <- reactive({
+      
+      req(pop_trend_data())
+      req(input$split_filter == "Deprivation (SIMD)")
+
+      # filter by selected indicator
+      dt <- pop_trend_data()
+      
+      # filter by quint type 
+      if(input$quint_type == "Scotland"){
+        dt <- dt[quint_type == "sc_quin"]
+      } else {
+        dt <- dt[quint_type != "sc_quin"]
+      }
+      
+      # get totals and rename them ready for joining
+      totals <- dt[split_value == "Total"]
+      setnames(totals, old = c("measure", "upci", "lowci"), new = c("avg", "avg_upci", "avg_lowci"))
+      totals <- totals[, c("trend_axis", "avg", "avg_upci", "avg_lowci")]
+
+      # remove totals from simd data
+      dt <- dt[split_value != "Total"]
+      
+      # add the totals back on as a column 
+      dt <- dt[totals, on = "trend_axis"]
+      # create colour palette
+      dt <- dt[, colour_pal := fcase(split_value == "1 - most deprived", phs_colors(colourname = "phs-blue"),
+                                     split_value == "2", colour = "#c8c6d1", # phs graphite (need colours that are unique for line chart but effectively not noticible when rendered)
+                                     split_value == "3", colour = "#c8c6d2", # phs graphite-ish
+                                     split_value == "4", colour = "#c8c6d3", # phs graphite -ish#2
+                                     default = phs_colors(colourname = "phs-magenta"))]
+      dt
+      
+    })
+
     # create single year data for the bar chart 
-    pop_rank_data <- reactive({
+    pop_bar_data <- reactive({
       req(pop_trend_data())
       pop_trend_data() |>
         filter(def_period == input$pop_years_filter) |>
         mutate(colour_pal = case_when(grepl("All", split_value) ~ phs_colors("phs-blue"), TRUE ~ phs_colors("phs-blue-50")))
     })
     
+    # SIMD: create single year data for the bar chart 
+    simd_pop_bar_data <- reactive({
+      req(simd_pop_trend_data())
+      simd_pop_trend_data() |>
+        filter(def_period == input$pop_years_filter) 
+    })
+    
+    
     #######################################################
     ## dynamic text  ----
     #######################################################
     
-    output$pop_rank_title <- renderUI({
+    output$pop_bar_title <- renderUI({
       # ensure there is data available, otherwise show message instead
       shiny::validate(
-        need( nrow(pop_trend_data()) > 0, "No indicators available")
+        need(nrow(pop_trend_data()) > 0, "No indicators available")
       )
       
       # if data is available display chart title
-      div(
-        tags$h5(selected_indicator(), "; split by ", input$split_filter, class = "chart-header"),
-        tags$h6(pop_rank_data()$trend_axis[1]), # time period 
-        tags$p(pop_rank_data()$rate_type[1]) # measure type
-      )
+      # If 2nd splits are available (i.e., only for SIMD currently), filter the data on the selected split2
+      if(input$split_filter == "Deprivation (SIMD)") { #will need generalising if other 1st splits are available
+        div(
+          tags$h5(selected_indicator(), " (", input$split2_filter, "); split by ", input$split_filter, class = "chart-header"),
+          tags$h6(pop_bar_data()$trend_axis[1]), # time period 
+          tags$p(pop_bar_data()$rate_type[1]) # measure type
+          )
+      } else {
+        div(
+          tags$h5(selected_indicator(), "; split by ", input$split_filter, class = "chart-header"),
+          tags$h6(pop_bar_data()$trend_axis[1]), # time period 
+          tags$p(pop_bar_data()$rate_type[1]) # measure type
+        )
+      }
     })
     
     # need to add pop-trend title stuff
@@ -290,79 +393,143 @@ pop_groups_server <- function(id, dataset, geo_selections) {
       
       # ensure there is data available, otherwise show message instead
       shiny::validate(
-        need( nrow(pop_trend_data()) > 3, "There are insufficent data points for this indicator to create a trend chart")
+        need(nrow(pop_trend_data()) > 3, "There are insufficent data points for this indicator to create a trend chart")
       )
       
       # if data is available display chart title
-      div(
-        tags$h5(selected_indicator(), "; split by ", input$split_filter, class = "chart-header"),
-        tags$h6(first(pop_trend_data()$trend_axis)," to ",last(pop_trend_data()$trend_axis)), # time period 
-        tags$p(pop_trend_data()$rate_type[1]) # measure type
-      )
+      # If 2nd splits are available (i.e., only for SIMD currently), filter the data on the selected split2
+      if(input$split_filter == "Deprivation (SIMD)") { #will need generalising if other 1st splits are available
+        div(
+          tags$h5(selected_indicator(), " (", input$split2_filter, "); split by ", input$split_filter, class = "chart-header"),
+          tags$h6(first(pop_trend_data()$trend_axis)," to ",last(pop_trend_data()$trend_axis)), # time period 
+          tags$p(pop_trend_data()$rate_type[1]) # measure type
+        )
+      } else {
+        div(
+          tags$h5(selected_indicator(), "; split by ", input$split_filter, class = "chart-header"),
+          tags$h6(first(pop_trend_data()$trend_axis)," to ",last(pop_trend_data()$trend_axis)), # time period 
+          tags$p(pop_trend_data()$rate_type[1]) # measure type
+        )
+      }
     })
+    
+    observeEvent(input$simd_help, {
+      showModal(modalDialog(
+        title = "About SIMD",
+        tagList(
+          #simd explanation
+          p("To prepare the charts shown we divide geographical areas into five groups (also known as quintiles) based on their relative levels of deprivation, as measured by the ",
+            tags$a(href="https://www2.gov.scot/simd",  "Scottish Index of Multiple Deprivation (SIMD).")),
+          p("Those living in areas assigned to quntile 1 experience the highest levels of relative deprivation and those living in quintile 5 the lowest relative deprivation."),
+          p("Geographical areas are assigned to a within Scotland quintile or a local quintile (e.g. within NHS board or within local authority quintile) based on the SIMD ranking."),
+          p("Indicator data for an NHS board or council area is presented by local deprivation quintiles by default. This tool allows users to switch from the default local quintiles to view the same data according to Scotland quintiles.")
+        ) #close taglist
+      ))
+    })
+    
+    
+    
     
     ############################################
     # charts -----
     #############################################
     
-    # pop rank bar chart  ---------------
+    # pop bar chart  ---------------
     
-    output$pop_rank_chart <- renderHighchart({
+    output$pop_bar_chart <- renderHighchart({
       
       shiny::validate(
-        need( nrow(pop_rank_data()) > 0, paste0("Data is not available at ", geo_selections()$areatype, " level. Please select either Scotland, Health board or Council area."))
+        need( nrow(pop_bar_data()) > 0, paste0("Data is not available at ", geo_selections()$areatype, " level. Please select a different area type (of either Scotland, Health board or Council area)."))
       )
+      
+      if(input$split_filter == "Deprivation (SIMD)") { #will need generalising if other 1st splits are available
+        bar_data <- simd_pop_bar_data()
+      } else {
+        bar_data <- pop_bar_data()
+      }
 
       
-      x <- hchart(pop_rank_data(), 
-                  type = "column", hcaes(x = split_value, y = measure, color = colour_pal)) %>%
+      x <- hchart(bar_data, 
+                  type = "column", hcaes(x = split_value, y = measure, color = colour_pal)) %>% 
         hc_yAxis(gridLineWidth = 0) %>%
         hc_chart(backgroundColor = 'white') %>%
         hc_xAxis(title = list(text = "")) %>%
         hc_yAxis(title = list(text = "")) %>%
         hc_plotOptions(series = list(animation = FALSE),
-                       column = list(groupPadding = 0))|>
-        # add extra bits to chart for downloaded version
-        hc_exporting(
-          filename = paste0("ScotPHO ", selected_indicator(), " split by ", input$split_filter),
-          chartOptions = list(
-            title = list(text = paste0(selected_indicator(), " split by ", input$split_filter)),
-            subtitle = list(text = paste0(pop_rank_data()$trend_axis[1])),
-            yAxis = list(title = list(text = paste0(pop_rank_data()$rate_type[1])))
-          )
-        )
-      
-      
+                       column = list(groupPadding = 0))
+
+      # incude average line if switch turned on
+      # N.B. only works for simd data currently: need to include more totals in the popgroup data
+      if(input$average_switch == TRUE){
+
+        x <- x |> hc_add_series(
+          name = "Average",
+          data = bar_data$avg,
+          type = "line",
+          color = "#C73918", #red colour for average line
+          marker = list(enabled = FALSE),
+          enableMouseTracking = FALSE) #turns off mouse tracking on average line only
+      }
       
       if(input$ci_switch) {
         x <- x |>
-          hc_add_series(pop_rank_data(), "errorbar", hcaes(x = split_value, low = lowci, high = upci), zIndex = 10)
+          hc_add_series(bar_data, "errorbar", hcaes(x = split_value, low = lowci, high = upci), zIndex = 10)
       }
+        
+        if(input$split_filter == "Deprivation (SIMD)") { #will need generalising if other 1st splits are available
+          x <- x |>
+            # add extra bits to chart for downloaded version
+            hc_exporting(
+              filename = paste0("ScotPHO ", selected_indicator(), " - ", input$split2_filter , " - split by ", input$split_filter), 
+              chartOptions = list(
+                title = list(text = paste0(selected_indicator(), " - ", input$split2_filter , " - split by ", input$split_filter)), 
+                subtitle = list(text = paste0(bar_data$trend_axis[1])),
+                yAxis = list(title = list(text = paste0(bar_data$rate_type[1])))
+              )
+            )  
+        } else {
+          x <- x |>
+            # add extra bits to chart for downloaded version
+            hc_exporting(
+              filename = paste0("ScotPHO ", selected_indicator(), " split by ", input$split_filter), 
+              chartOptions = list(
+                title = list(text = paste0(selected_indicator(), " split by ", input$split_filter)), 
+                subtitle = list(text = paste0(bar_data$trend_axis[1])),
+                yAxis = list(title = list(text = paste0(bar_data$rate_type[1])))
+              )
+            )
+        }
+        
       
       x
 
       
-    }) # end pop_rank_chart
+    }) # end pop_bar_chart
     
     # pop trend bar chart  ---------------
     
     output$pop_trend_chart <- renderHighchart({
       
+      if(input$split_filter == "Deprivation (SIMD)") { #will need generalising if other 1st splits are available
+        trend_data <- simd_pop_trend_data()
+      } else {
+        trend_data <- pop_trend_data()
+      }
       
       # create vector of colours - needs to be the same length as the 
       # number of lines that need to be plotted otherwise CI colours (the lighter colour plotted behind the main line)
       # wont match up properly
       purple_and_blues <- unname(phs_colours()[grepl("blue|purple", names(phs_colours()))])
-      colours <- head(purple_and_blues, length(unique(pop_trend_data()$split_value)))
+      colours <- head(purple_and_blues, length(unique(trend_data$split_value)))
       
       
-      x <- hchart(pop_trend_data(), 
+      x <- hchart(trend_data, 
                   "line",
                   hcaes(x = trend_axis, y = measure, group = split_value)) |>
         hc_yAxis(gridLineWidth = 0) |> # remove gridlines 
         hc_xAxis(title = list(text = "")) |>
         hc_yAxis(title = list(text = "")) |>
-        hc_xAxis(categories = unique(pop_trend_data()$trend_axis)) |>
+        hc_xAxis(categories = unique(trend_data$trend_axis)) |>
         # style xaxis labels - keeping only first and last label
         hc_xAxis(labels = list(
           rotation = 0,
@@ -378,30 +545,19 @@ pop_groups_server <- function(id, dataset, geo_selections) {
                }
              }"))) |>
         hc_chart(backgroundColor = 'white') |>
-        hc_plotOptions(series = list(animation = FALSE)) |>
+        hc_plotOptions(series = list(animation = FALSE,
+                                     connectNulls=TRUE)) |>
         hc_tooltip(
           crosshairs = TRUE,
           borderWidth = 1,
           table = TRUE
-        ) |>
-        # add extra bits to chart for downloaded version
-        hc_exporting(
-          filename = paste0("ScotPHO trend - ", selected_indicator(), " split by ", input$split_filter),
-          chartOptions = list(
-            title = list(text = paste0(selected_indicator(), " split by ", input$split_filter)),
-            subtitle = list(text = paste0(first(pop_trend_data()$trend_axis)," to ",last(pop_trend_data()$trend_axis))),
-            yAxis = list(title = list(text = paste0(pop_trend_data()$rate_type[1])))
-          )
-        )
-      
-
-      
+        ) 
       
       # if the confidence interval switch turned on, plot cis
       if(input$trend_ci_switch == TRUE){
         
         x <- x |>
-          hc_add_series(pop_trend_data(), 
+          hc_add_series(trend_data, 
                         type = "arearange", 
                         hcaes(x = trend_axis, low = lowci, high = upci, group = split_value),  
                         color = hex_to_rgba("grey", 0.2), 
@@ -415,9 +571,45 @@ pop_groups_server <- function(id, dataset, geo_selections) {
                                           enabled = FALSE))))
       }
       
-      x <- x |>
-        # add phs colours
-        hc_colors(colours)
+      if(input$split_filter == "Deprivation (SIMD)") { #will need generalising if other 1st splits are available
+        x <- x |>
+          # add SIMD colour pal
+          hc_colors(unique(trend_data$colour_pal)) |>
+          # add extra bits to chart for downloaded version
+          hc_exporting(
+            filename = paste0("ScotPHO trend - ", selected_indicator(), " - ", input$split2_filter , " - split by ", input$split_filter),
+            chartOptions = list(
+              title = list(text = paste0(selected_indicator(), " - ", input$split2_filter , " - split by ", input$split_filter)),
+              subtitle = list(text = paste0(first(trend_data$trend_axis)," to ",last(trend_data$trend_axis))),
+              yAxis = list(title = list(text = paste0(trend_data$rate_type[1])))
+            )
+          )     
+        } else {
+        x <- x |>
+          # add phs colours
+          hc_colors(colours) |>
+          # add extra bits to chart for downloaded version
+          hc_exporting(
+            filename = paste0("ScotPHO trend - ", selected_indicator(), " split by ", input$split_filter),
+            chartOptions = list(
+              title = list(text = paste0(selected_indicator(), " split by ", input$split_filter)),
+              subtitle = list(text = paste0(first(trend_data$trend_axis)," to ",last(trend_data$trend_axis))),
+              yAxis = list(title = list(text = paste0(trend_data$rate_type[1])))
+            )
+          )
+        }
+      
+      # add average line if switch turned on 
+      if(input$average_switch == TRUE){
+        
+        x <- x |> hc_add_series(
+          trend_data,
+          "line",
+          name = "Average",
+          color = "#C73918",
+          hcaes(x = trend_axis, y = avg)
+        )
+      } 
       
       x
       
@@ -430,27 +622,64 @@ pop_groups_server <- function(id, dataset, geo_selections) {
     # Tables ---------
     ###########################################
     
-    # rank data table -------
-    output$pop_rank_table <- renderReactable({
+    # bar data table -------
+    output$pop_bar_table <- renderReactable({
       
-      data <- pop_rank_data() |>
-        select(def_period, split_value, measure)
+      if(input$split_filter == "Deprivation (SIMD)") { #will need generalising if other 1st splits are available
+        data <- simd_pop_bar_data() |>
+          select(def_period, split_value2, split_value, measure)
+        
+        reactable(data = data,
+                  defaultExpanded = TRUE,
+                  defaultPageSize = nrow(data),
+                  # rename some columns 
+                  columns = list(
+                    def_period = colDef(name = "Time Period"),
+                    split_value2 = colDef(name = "Population Group 1"),
+                    split_value = colDef(name = "Population Group 2"),
+                    measure = colDef(name = "Measure")
+                  )
+        )
+        
+      } else {
+        data <- pop_bar_data() |>
+          select(def_period, split_value, measure)
+        
+        reactable(data = data,
+                  defaultExpanded = TRUE,
+                  defaultPageSize = nrow(data),
+                  # rename some columns 
+                  columns = list(
+                    def_period = colDef(name = "Time Period"),
+                    split_value = colDef(name = "Population Group"),
+                    measure = colDef(name = "Measure")
+                  )
+        )
+      }
       
-      reactable(data = data,
-                defaultExpanded = TRUE,
-                defaultPageSize = nrow(data),
-                # rename some columns 
-                columns = list(
-                  def_period = colDef(name = "Time Period"),
-                  split_value = colDef(name = "Population Group"),
-                  measure = colDef(name = "Measure")
-                )
-      )
     })
     
     # trend data table -------
     output$pop_trend_table <- renderReactable({
       
+      if(input$split_filter == "Deprivation (SIMD)") { #will need generalising if other 1st splits are available
+        
+        data <- simd_pop_trend_data() |>
+          select(def_period, split_value2, split_value, measure)
+        
+        reactable(data = data,
+                  defaultExpanded = TRUE,
+                  defaultPageSize = nrow(data),
+                  # rename some columns 
+                  columns = list(
+                    def_period = colDef(name = "Time Period"),
+                    split_value2 = colDef(name = "Population Group 1"),
+                    split_value = colDef(name = "Population Group 2"),
+                    measure = colDef(name = "Measure")
+                  )
+        )
+      } else {
+        
       data <- pop_trend_data() |>
         select(def_period, split_value, measure)
       
@@ -464,7 +693,7 @@ pop_groups_server <- function(id, dataset, geo_selections) {
                   measure = colDef(name = "Measure")
                 )
       )
-      
+      }
       
     })
     
@@ -478,11 +707,96 @@ pop_groups_server <- function(id, dataset, geo_selections) {
     ############################################
     # Downloads  ----
     #############################################
-    download_chart_mod_server(id = "save_pop_rankchart", chart_id = ns("pop_rank_chart"))
-    download_data_btns_server(id = "pop_rank_download", data = pop_trend_data, file_name = "Popgroup_ScotPHO_data_extract")
+    download_chart_mod_server(id = "save_pop_barchart", chart_id = ns("pop_bar_chart"))
+    download_data_btns_server(id = "pop_bar_download", data = pop_trend_data, file_name = "Popgroup_ScotPHO_data_extract")
     
     download_chart_mod_server(id = "save_pop_trendchart", chart_id = ns("pop_trend_chart"))
     download_data_btns_server(id = "pop_trend_download", data = pop_trend_data, file_name = "Popgroup_ScotPHO_data_extract")
-  } # module server
+  
+    
+    ############################################
+    # Guided tour
+    ###########################################
+    
+    guide_deprivation <- Cicerone$
+      new()$
+      step(
+        ns("simd_barchart"),
+        "Bar Chart",
+        "This chart shows how the selected measure varies according to the relative deprivation of an area of residence, 
+        It allows comparison of the most and least deprived areas.",
+        position = "right",
+        tab_id = ns("deprivation_navset_card_pill_barchart"),
+        tab = ns("deprivation_barchart_tab")
+      )$
+      step(
+        ns("simd_trendchart"),
+        "Linechart Tab",
+        "This chart shows the value of a measure by deprivation quintile over time. 
+        It allows comparison of the most and least deprived areas over time.",
+        position = "left",
+        tab_id = ns("deprivation_navset_card_pill_linechart"),
+        tab = ns("deprivation_linechart_tab")
+      )$
+      step(
+        ns("deprivation_navset_card_pill_linechart"),
+        "Other views",
+        "You can switch between viewing charts, the data or the metadata using the buttons above each chart."
+      )$
+      step(
+        ns("depr_popover"),
+        "Chart controls",
+        "You can switch between viewing charts, the data or the metadata using the buttons above each chart."
+      )$
+      step(
+        ns("deprivation_indicator_filter_wrapper"), 
+        "Indicator Filter",
+        "First select an indicator.<br>
+        The indicator list has been filtered based on profile and area type selected at the top of the page.<br>
+        The backspace can be used to remove the default selection. Indicators can then be searched by topic or name.",
+        position = "right"
+      )$
+      step(
+        ns("simd_help"),
+        "Information on SIMD",
+        "Click here for more information on SIMD",
+        position = "right"
+      )$
+      step(
+        ns("deprivation_avg_switch_wrapper"),
+        "Average Line",
+        "Click to add or remove a trend line showing the average for the measure across all quintiles.",
+        position = "right"
+      )$
+      step(
+        ns("deprivation_quintile_type_wrapper"),
+        "Quintile Type",
+        "When an area other than Scotland is selected, click here to toggle between local and Scottish quintiles.",
+        position = "right"
+      )$
+      step(
+        ns("deprivation_download_chart"),
+        "Download Chart Button",
+        "Click here to download this chart as a PNG.",
+        position = "above"
+      )$
+      step(
+        ns("deprivation_download_data"),
+        "Download Data Button",
+        "Click here to download the selected data as a CSV, RDS or JSON file.",
+        position = "above")
+    #add step for tooltips
+    
+    
+    #initiate the guide
+    guide_deprivation$init()
+    
+    #when guided tour button is clicked, start the guide
+    observeEvent(input$deprivation_tour_button, {
+      guide_deprivation$start()
+    })
+  
+    
+    } # module server
   )# module server
 } # pop groups server

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -191,7 +191,7 @@ function(input, output, session) {
     req(input$profile_choices != "")
     if (profiles_list[[input$profile_choices]] %in% c("CWB", "MEN") & !is.null(profiles_list[[input$profile_choices]])) {
       nav_show("sub_tabs", target = "pop_groups_tab")
-      pop_groups_server("pop_groups",popgroup_data, geo_selections)
+      pop_groups_server("pop_groups",popgroup_data, geo_selections, reactive({input$profile_choices}))
     } else {
       nav_hide("sub_tabs", target = "pop_groups_tab")
     }

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -321,11 +321,11 @@ function(input, output, session) {
   # filters the population groups dataset by selected profile, filtered data then passed to the pop group visualisation module 
   popgroup_data <- reactive({
     
-    req(profiles_list[[input$profile_choices]] %in% c("CWB", "MEN")) # only run when specific profiles have been selected
+    req(profiles_list[[input$profile_choices]] %in% c("CWB", "MEN", "HWB", "CYP")) # only run when specific profiles have been selected
 
     dt <- setDT(popgroup_dataset) # set to class data.table
     
-    # filter by selected geography as deprivation tab only displays info on a single area
+    # filter by selected geography as popgroups tab only displays info on a single area
     dt <- dt[(areatype == geo_selections()$areatype | areatype == "Scotland") & areaname == geo_selections()$areaname]
     
     # filter rows where profile abbreviation exists in one of the 3 profile_domain columns in the technical document


### PR DESCRIPTION
Contains the data prep script and changes to the popgroup tab so that SIMD can be included as a possible split, when available, and a second split filter (e.g. sex) can be selected if this is available. The specifics of the new data format required are noted in the script combine_popgroup_and_simd_data.R, which should be run before running the app from this branch. 

If this branch is OK it would mean the deprivation tab could be removed, and new plots for RII, SII and PAR could be added to the popgroup tab (conditional on SIMD being selected as a split)