### PR TITLE
ER Combining deprivation and popgroups tabs (2nd attempt)

### DIFF
--- a/data_preparation/1_ScotPHO_profiles_data_preparation.R
+++ b/data_preparation/1_ScotPHO_profiles_data_preparation.R
@@ -52,8 +52,9 @@ source("data_preparation/2_dataprep_validation_tests.R") # validation checks
 source("data_preparation/update_techdoc.R") # script to read in & format techdoc
 source("data_preparation/update_shapefiles.R") # script to read in & format shapefiles
 source("data_preparation/update_deprivation_data.R") # script to read in & format deprivation data
-source("data_preparation/update_main_data.R") # script to read in and forma main data
-source("data_preparation/update_popgroup_data.R") # script to read in and forma main data
+source("data_preparation/update_main_data.R") # script to read in and format main data
+source("data_preparation/update_popgroup_data.R") # script to read in and format popgroup data
+source("data_preparation/combine_popgroup_and_simd_data.R") # script to combine popgroup and deprivation data
 
 
 ###################################################.
@@ -169,6 +170,16 @@ TEST_inequalities_trends(deprivation_dataset) # checks if last deprivation indic
 update_popgroup_data(load_test_indicators = TRUE, create_backup = FALSE)
 
 # no validation tests currently written for population data.
+
+
+
+########################################################################.
+## Combine popgroups and deprivation data  ----
+########################################################################.
+
+combine_popgroup_and_simd_data(create_backup = FALSE)
+
+# no validation tests currently written.
 
 
 ############################################################.

--- a/data_preparation/combine_popgroup_and_simd_data.R
+++ b/data_preparation/combine_popgroup_and_simd_data.R
@@ -53,7 +53,7 @@ combine_popgroup_and_simd_data <- function(create_backup = FALSE) {
   popgroup_std <- popgroup %>%
     mutate(split_name = case_when(split_name=="Gender" ~ "Sex", # some also have split_name == Total when split_value==All: how to use?
                                   split_name %in% c("Scottish Index of Multiple Deprivation", "SIMD") ~ "Deprivation (SIMD)",
-                                  split_name %in% c("Long-term physical/mental health condition", "Longterm conditions") ~ "Long-term conditions",
+                                  split_name %in% c("Long-term physical/mental health condition", "Limiting Longstanding Illness", "Longterm conditions") ~ "Long-term conditions",
                                   split_name %in% c("Equivalised income", "Equivalised Income") ~ "Income (Equivalised)",
                                   TRUE ~ split_name)) %>%
     mutate(split_value = case_when(split_value %in% c("1st-Top quintile", "Top Quintile") ~ "1 - highest income",
@@ -70,9 +70,9 @@ combine_popgroup_and_simd_data <- function(create_backup = FALSE) {
                                    split_value=="All sexes" ~ "Total",
                                    split_value %in% c("Males", "Men") ~ "Male",
                                    split_value %in% c("Females", "Women") ~ "Female",
-                                   split_name=="Long-term conditions" & split_value %in% c("Limiting long-term conditions", "Limiting long-term illness") ~ "Yes, limiting",
-                                   split_name=="Long-term conditions" & split_value %in% c("Non-limiting long-term conditions", "Non-limiting long-term illness") ~ "Yes, but not limiting",
-                                   split_name=="Long-term conditions" & split_value %in% c("No long-term conditions", "No long-term illness") ~ "No",
+                                   split_name=="Long-term conditions" & split_value %in% c("Limiting long-term conditions", "Limiting long-term illness", "Limiting Longstanding Illness") ~ "Yes, limiting",
+                                   split_name=="Long-term conditions" & split_value %in% c("Non-limiting long-term conditions", "Non-limiting long-term illness", "Non to Limiting Longstanding Illness") ~ "Yes, but not limiting",
+                                   split_name=="Long-term conditions" & split_value %in% c("No long-term conditions", "No long-term illness", "No Longstanding Illness") ~ "No",
                                    split_value %in% c("Working to age adults", "Working age adults") ~ "Working-age adults",
                                    split_value %in% c("All ages", "All") ~ "Total",
                                    split_value== "Not Disabled" ~ "Not disabled",

--- a/data_preparation/combine_popgroup_and_simd_data.R
+++ b/data_preparation/combine_popgroup_and_simd_data.R
@@ -1,0 +1,199 @@
+
+## FUNCTION: combine_popgroup_and_simd_data() ----
+
+## Combines latest popgroup_dataset and deprivation_dataset to create a single parquet data file within local shiny app data folder.
+## The new file - popgroup_dataset.R - will populate the population group tab in the app.
+## This shows indicators split by various equality splits, including age/sex/disability/SIMD etc
+## The new data format introduced here allows for a second split column (split_value2).
+## Currently split_value2 is only used for sex split when the split_name is SIMD, but there is scope for other multi-way splits.
+
+## DATA FORMAT
+
+## split_name
+## Same as in original popgroup_dataset: this populates the first split filter "Select population split"
+## This script standardises the split_names used.
+## Current split_name options: "Age", "Income (Equivalised)", "Long-term conditions", "Sex", "Deprivation (SIMD)", "Urban/Rural".
+## Any rows with split_name=="Total" should be dropped.
+## Deprivation should always be in split_name rather than split_value2, because its data needs to be treated differently.
+## This means the other splits can be in either column, depending on whether also combined with SIMD or not.
+
+## split_value2 
+## A new variable, which populates the second split filter "Select 2nd population split:"
+## Current values for split_value2 are "Male", "Female", "Total". 
+## split_value2 should be NA if the data relate to a single split
+
+## split_value
+## These are the splits displayed in the charts (as in original popgroup_dataset), and the function standardises these:
+## ages e.g., "0 to 4 years", "60+ years", "Children", "Working-age adults", "Pensioners" (latter 3 could do with age ranges being given too)
+## income: "1 - highest income" to "5 - lowest income"
+## Long-term conditions: "No", "Yes, but not limiting", "Yes, limiting"
+## Sex: Female, Male, Total 
+## SIMD: "1 - most deprived" to "5 - least deprived", and "Total"
+## Urb/Rural: "1 Large urban areas" to "6 Remote rural"
+## split_value == "Total" is what is used to plot the average on the charts, if selected. 
+## In many cases this is not in the original data, so the function extracts the relevant "Total" split - by def_period, code, and ind_id - and appends this.
+
+## quint_type 
+## only applies to SIMD data, and has been assumed to be scotland (sc_quin) unless specified. 
+## Check this assumption is correct. Applies to HWB and CWB profiles only (when SIMD data were included in their popgroup rather than deprivation data)
+
+## PARAMETERS
+# create_backup :  (default is FALSE ) option to set to TRUE when creating a distinct backup version desired e.g. when planning to deploy the app
+
+combine_popgroup_and_simd_data <- function(create_backup = FALSE) {
+
+  ############################################
+  # Processing the popgroup_dataset
+  ############################################
+  
+  # Original popgroup dataset:  
+  popgroup <- read_parquet(paste0(test_shiny_files, "/processed_intermediate_datasets/popgroup_dataset")) # result of update_popgroup_data.R
+  
+  # standardise the splits:
+  popgroup_std <- popgroup %>%
+    mutate(split_name = case_when(split_name=="Gender" ~ "Sex", # some also have split_name == Total when split_value==All: how to use?
+                                  split_name %in% c("Scottish Index of Multiple Deprivation", "SIMD") ~ "Deprivation (SIMD)",
+                                  split_name %in% c("Long-term physical/mental health condition", "Longterm conditions") ~ "Long-term conditions",
+                                  split_name=="Equivalised income" ~ "Income (Equivalised)",
+                                  TRUE ~ split_name)) %>%
+    mutate(split_value = case_when(split_value=="1st-Top quintile" ~ "1 - highest income",
+                                   split_value=="2nd quintile" ~ "2",
+                                   split_value=="3rd quintile" ~ "3",
+                                   split_value=="4th quintile" ~ "4",
+                                   split_value=="5th-Bottom quintile" ~ "5 - lowest income",
+                                   split_value=="1st-Most deprived" ~ "1 - most deprived",
+                                   split_value=="2nd" ~ "2",
+                                   split_value=="3rd" ~ "3",
+                                   split_value=="4th" ~ "4",
+                                   split_value=="5th-Least deprived" ~ "5 - least deprived",
+                                   split_value=="5 - most deprived" ~ "5 - least deprived", # checked the data to confirm this was coded wrong
+                                   split_value=="All sexes" ~ "Total",
+                                   split_value=="Males" ~ "Male",
+                                   split_value=="Females" ~ "Female",
+                                   split_name=="Long-term conditions" & split_value %in% c("Limiting long-term conditions", "Limiting long-term illness") ~ "Yes, limiting",
+                                   split_name=="Long-term conditions" & split_value %in% c("Non-limiting long-term conditions", "Non-limiting long-term illness") ~ "Yes, but not limiting",
+                                   split_name=="Long-term conditions" & split_value %in% c("No long-term conditions", "No long-term illness") ~ "No",
+                                   split_value %in% c("Working to age adults", "Working age adults") ~ "Working-age adults",
+                                   split_value %in% c("All ages", "All") ~ "Total",
+                                   split_name=="Age" ~ gsub("-", " to ", split_value),
+                                   TRUE ~ split_value)) %>%
+    mutate(split_value = case_when(split_name=="Age" ~ gsub("Aged ", "", split_value),
+                                   TRUE ~ split_value)) %>%
+    mutate(split_value = case_when(split_name=="Age" & grepl("^[0-9]", split_value)==TRUE ~ paste0(split_value, " years"), 
+                                   TRUE ~ split_value)) %>%
+    mutate(split_value2 = case_when(split_name == "Deprivation (SIMD)" ~ "Total", # i.e., all sexes
+                                    TRUE ~ as.character(NA))) %>%
+    mutate(quint_type = case_when(split_name == "Deprivation (SIMD)" ~ "sc_quin", # an assumption: check
+                                  TRUE ~ as.character(NA))) %>%
+    filter(!split_name=="Total") #%>%
+  # filter(!ind_id %in% c(30000:39999)) # remove original MHI data, as adding in more complete set (with SIMD x sex)
+  
+  # #check what splits are now used:
+  # popgroup_std_splits <- popgroup_std %>% # 
+  #   select(split_value, split_value2, 
+  #          split_name) %>%
+  #   unique()        
+  
+  # find which popgroup splits don't have total
+  popgp_have_total <- popgroup_std %>%
+    mutate(total_exists = ifelse(split_value=="Total", 1, 0)) %>%
+    group_by(year, code, ind_id, def_period, split_name) %>%
+    summarise(has_total = sum(total_exists)) %>%
+    ungroup()
+  
+  # table(popgp_have_total$has_total)
+  # #0    1     
+  # #7379 2753    
+  
+  # get totals for those with has_total==0:
+  no_totals <- popgp_have_total %>% # n=7379
+    filter(has_total==0) %>%
+    select(-has_total)
+  
+  totals <- read_parquet("shiny_app/data/main_dataset") %>% # main dataset 
+    merge(y=no_totals, by=c("year", "def_period", "code", "ind_id"), all.y=T)
+  
+  # #some data with splits have no totals available in the main_dataset:
+  # ind_w_no_totals <- totals %>% #n=204
+  #   filter(is.na(indicator))
+  # 
+  # table(ind_w_no_totals$ind_id)
+  # # 30057 99105 99106 99107 99108 99109 99116 99117 99118 99121 99123 
+  # # 2    12    42    10    42    28     8     6    10    12    32 
+  # # 10 CWB indicators: 99105-109, 99116-118, 99121, 99123 and 1 MHI: 30057 (violent crime, because SCJS pooled some years for police div estimates)
+  
+  
+  # prep the total rows for appending to the rest of the data
+  totals_4_popgroup_data <- totals %>%
+    filter(!is.na(indicator)) %>% # drops those with no totals
+    mutate(split_value="Total",
+           split_value2=ifelse(split_name=="Deprivation (SIMD)", "Total", as.character(NA)),
+           quint_type = ifelse(split_name=="Deprivation (SIMD)", "sc_quin", as.character(NA))) # all missing quint_types assumed to be sc_quin
+  
+  
+  ############################################
+  # Processing the deprivation_dataset
+  ############################################
+  
+  # Original deprivation dataset:  
+  simd <- read_parquet(paste0(test_shiny_files, "/processed_intermediate_datasets/deprivation_dataset")) %>% # result of update_deprivation_data.R
+    mutate(split_value2=case_when(sex=="Male" ~ "Male",
+                                  sex=="Female" ~ "Female",
+                                  sex=="Total" ~ "Total",
+                                  is.na(sex) ~ "Total"),
+           #  quint_type = case_when(is.na(quint_type) ~ "sc_quin", # all have quint_type, so this assumption not needed
+           #                         TRUE ~ quint_type),
+           split_name = "Deprivation (SIMD)") %>%
+    rename(split_value = quintile) 
+  
+  # # do any simd splits not have total?
+  # have_total <- read_parquet(paste0(test_shiny_files, "/processed_deprivation_dataset/deprivation_dataset")) %>%
+  #   mutate(total_quint = ifelse(quintile=="Total", 1, 0)) %>%
+  #   group_by(year, def_period, code, ind_id, sex, quint_type) %>%
+  #   summarise(has_total = sum(total_quint)) %>%
+  #   ungroup()
+  # all SIMD data in the deprivation data have quintile==Total (used for averages)
+  
+  # #check what splits are now used:
+  # simd_splits <- simd %>% # 
+  #   select(split_value, split_value2, 
+  #          split_name) %>%
+  #   unique()       
+  
+  
+  ############################################
+  # Appending the datasets
+  ############################################
+  
+  popgroup_dataset <- bind_rows(popgroup_std, totals_4_popgroup_data, simd) %>% 
+    arrange(ind_id, year, code, split_name, split_value, split_value2)
+  
+  # # what are the splits and names now?
+  # popgroup_new_splits <- popgroup_new %>% # 42 vars
+  #   select(split_value, split_value2, split_name) %>%
+  #   unique()
+  
+  # make available in global environment for viewing what will be sent to shiny app
+  popgroup_dataset <<- popgroup_dataset
+  
+  ## save final file to local repo
+  write_parquet(popgroup_dataset, "shiny_app/data/popgroup_dataset")
+  
+  
+  ## Optional: Create backup of from local repo -----
+  ## Usually would only want to create a backup if you intend to update live tool
+  ## This file will be stored in backups folder and could be used to roll back app to a particular date
+  if (create_backup == TRUE) {
+    
+    file.copy(
+      "/shiny_app/data/popgroup_dataset", 
+      paste0(backups, "popgroup_dataset", Sys.Date()), 
+      overwrite = TRUE
+    )
+  } 
+
+} #close function
+
+#END.
+
+

--- a/data_preparation/combine_popgroup_and_simd_data.R
+++ b/data_preparation/combine_popgroup_and_simd_data.R
@@ -54,13 +54,13 @@ combine_popgroup_and_simd_data <- function(create_backup = FALSE) {
     mutate(split_name = case_when(split_name=="Gender" ~ "Sex", # some also have split_name == Total when split_value==All: how to use?
                                   split_name %in% c("Scottish Index of Multiple Deprivation", "SIMD") ~ "Deprivation (SIMD)",
                                   split_name %in% c("Long-term physical/mental health condition", "Longterm conditions") ~ "Long-term conditions",
-                                  split_name=="Equivalised income" ~ "Income (Equivalised)",
+                                  split_name %in% c("Equivalised income", "Equivalised Income") ~ "Income (Equivalised)",
                                   TRUE ~ split_name)) %>%
-    mutate(split_value = case_when(split_value=="1st-Top quintile" ~ "1 - highest income",
+    mutate(split_value = case_when(split_value %in% c("1st-Top quintile", "Top Quintile") ~ "1 - highest income",
                                    split_value=="2nd quintile" ~ "2",
                                    split_value=="3rd quintile" ~ "3",
                                    split_value=="4th quintile" ~ "4",
-                                   split_value=="5th-Bottom quintile" ~ "5 - lowest income",
+                                   split_value %in% c("5th-Bottom quintile", "Bottom Quintile") ~ "5 - lowest income",
                                    split_value=="1st-Most deprived" ~ "1 - most deprived",
                                    split_value=="2nd" ~ "2",
                                    split_value=="3rd" ~ "3",
@@ -68,13 +68,14 @@ combine_popgroup_and_simd_data <- function(create_backup = FALSE) {
                                    split_value=="5th-Least deprived" ~ "5 - least deprived",
                                    split_value=="5 - most deprived" ~ "5 - least deprived", # checked the data to confirm this was coded wrong
                                    split_value=="All sexes" ~ "Total",
-                                   split_value=="Males" ~ "Male",
-                                   split_value=="Females" ~ "Female",
+                                   split_value %in% c("Males", "Men") ~ "Male",
+                                   split_value %in% c("Females", "Women") ~ "Female",
                                    split_name=="Long-term conditions" & split_value %in% c("Limiting long-term conditions", "Limiting long-term illness") ~ "Yes, limiting",
                                    split_name=="Long-term conditions" & split_value %in% c("Non-limiting long-term conditions", "Non-limiting long-term illness") ~ "Yes, but not limiting",
                                    split_name=="Long-term conditions" & split_value %in% c("No long-term conditions", "No long-term illness") ~ "No",
                                    split_value %in% c("Working to age adults", "Working age adults") ~ "Working-age adults",
                                    split_value %in% c("All ages", "All") ~ "Total",
+                                   split_value== "Not Disabled" ~ "Not disabled",
                                    split_name=="Age" ~ gsub("-", " to ", split_value),
                                    TRUE ~ split_value)) %>%
     mutate(split_value = case_when(split_name=="Age" ~ gsub("Aged ", "", split_value),
@@ -85,8 +86,7 @@ combine_popgroup_and_simd_data <- function(create_backup = FALSE) {
                                     TRUE ~ as.character(NA))) %>%
     mutate(quint_type = case_when(split_name == "Deprivation (SIMD)" ~ "sc_quin", # an assumption: check
                                   TRUE ~ as.character(NA))) %>%
-    filter(!split_name=="Total") #%>%
-  # filter(!ind_id %in% c(30000:39999)) # remove original MHI data, as adding in more complete set (with SIMD x sex)
+    filter(!split_name=="Total") 
   
   # #check what splits are now used:
   # popgroup_std_splits <- popgroup_std %>% # 

--- a/data_preparation/update_deprivation_data.R
+++ b/data_preparation/update_deprivation_data.R
@@ -50,7 +50,8 @@ update_deprivation_data <- function(load_test_indicators = FALSE, create_backup 
     mutate(quintile = recode(quintile,"1" = "1 - most deprived","5" = "5 - least deprived")) |>
     mutate_at(c("numerator", "measure", "lowci", "upci", "rii", "upci_rii",
                 "lowci_rii", "sii", "lowci_sii", "upci_sii", "par", "abs_range",
-                "rel_range", "rii_int", "lowci_rii_int", "upci_rii_int"),round, 1)
+                "rel_range", "rii_int", "lowci_rii_int", "upci_rii_int"),round, 1) 
+
   
   ## apply suppression function ----
   deprivation_dataset <- deprivation_dataset |>
@@ -75,16 +76,20 @@ update_deprivation_data <- function(load_test_indicators = FALSE, create_backup 
   # most geographies have 2 parts to their path i.e. 'Health Board/NHS Ayrshire & Arran'
   deprivation_dataset <- create_geography_path_column(deprivation_dataset)
   
-  # make dataset available in global environment for validation tests
-   deprivation_dataset_validation <<- deprivation_dataset 
 
-  # Make dataset visible outside of function
-  deprivation_dataset <<- deprivation_dataset %>%
+  # Remove columns not required in app
+  deprivation_dataset <- deprivation_dataset %>%
     select(-c("file_name", "parent_area", # deselect columns not required in shiny app
               #"areaname_full" #areaname_full required to make validation test work
               "supression", "supress_less_than")) # additional columns need to be removed to make the validation test work for ineq data
   
- 
+  # restrict to distinct rows (deals with situation if there are duplicates of the input files (or in these files): occurs in CWB)
+  deprivation_dataset <- deprivation_dataset |>
+    distinct() 
+  
+  # make dataset available in global environment for validation tests
+  deprivation_dataset_validation <<- deprivation_dataset 
+  
   #write parquet file to ScotPHO data folder, before combining with the popgroups file
   write_parquet(deprivation_dataset, paste0(test_shiny_files, "/processed_intermediate_datasets/deprivation_dataset"))
   

--- a/data_preparation/update_deprivation_data.R
+++ b/data_preparation/update_deprivation_data.R
@@ -58,7 +58,7 @@ update_deprivation_data <- function(load_test_indicators = FALSE, create_backup 
   
   ## create new fields ----
   deprivation_dataset <- deprivation_dataset |>
-    group_by(ind_id, year, quint_type, code) |>
+    group_by(ind_id, year, quint_type, code, sex) |>
     # label if par, sii or rii  positive or negative (helps with health inequality dynamic summary text)
     mutate(across(c(sii, rii, par),
              ~ case_when(. > 0 ~ "positive", . < 0 ~ "negative",  . == 0 ~ "zero"),
@@ -85,8 +85,8 @@ update_deprivation_data <- function(load_test_indicators = FALSE, create_backup 
               "supression", "supress_less_than")) # additional columns need to be removed to make the validation test work for ineq data
   
  
-  #write parquet file to shiny app data folder
-  write_parquet(deprivation_dataset, "shiny_app/data/deprivation_dataset")
+  #write parquet file to ScotPHO data folder, before combining with the popgroups file
+  write_parquet(deprivation_dataset, paste0(test_shiny_files, "/processed_intermediate_datasets/deprivation_dataset"))
   
   
   ## Optional: Create backup of from local repo -----
@@ -96,7 +96,7 @@ update_deprivation_data <- function(load_test_indicators = FALSE, create_backup 
   if (create_backup == TRUE) {
     
     file.copy(
-      "shiny_app/data/deprivation_dataset", 
+      paste0(test_shiny_files, "processed_intermediate_datasets/deprivation_dataset"), 
       paste0(backups, "deprivation_dataset_", Sys.Date()), 
       overwrite = TRUE
     )

--- a/data_preparation/update_main_data.R
+++ b/data_preparation/update_main_data.R
@@ -81,7 +81,7 @@ main_dataset <- main_dataset |>
     )
   )
 
-
+  
 # some indicators have years missing from their dataset (e.g. if no data was collected that year due to covid)
 # To ensure that the data in the trend tab doesn't drop to 0 for those years, we create data for those missing years
 # and populate the measure with 'NA' instead - this creates a gap in the trend chart, instead of an incorrect drop to 0
@@ -138,6 +138,9 @@ main_dataset <- main_dataset |>
 # with the exception of IZs/HSC Localities where a parent area is also included i.e. 'HSC Locality/Edinburgh City/Edinburgh North-East'
 main_dataset <- create_geography_path_column(main_dataset)
 
+## restrict to distinct rows (deals with situation if there are duplicates of the input files (or in these files): occurs in CWB)
+main_dataset <- main_dataset |>
+  distinct() 
 
 # make available in global environment for viewing what will be sent to shiny app
 main_dataset <<- main_dataset

--- a/data_preparation/update_popgroup_data.R
+++ b/data_preparation/update_popgroup_data.R
@@ -78,8 +78,8 @@ update_popgroup_data <- function(load_test_indicators = FALSE, create_backup = F
   # make available in global environment for viewing what will be sent to shiny app
   popgroup_dataset <<- popgroup_dataset
   
-  ## save final file to local repo
-  write_parquet(popgroup_dataset, "shiny_app/data/popgroup_dataset")
+  #write parquet file to ScotPHO data folder, before combining with the deprivation file
+  write_parquet(popgroup_dataset, paste0(test_shiny_files, "/processed_intermediate_datasets/popgroup_dataset"))
   
   ## Optional: Create backup of from local repo -----
   ## Usually would only want to create a backup if you intend to update live tool
@@ -87,7 +87,7 @@ update_popgroup_data <- function(load_test_indicators = FALSE, create_backup = F
   if (create_backup == TRUE) {
     
     file.copy(
-      "shiny_app/data/popgroup_dataset", 
+      paste0(test_shiny_files, "/processed_intermediate_datasets/popgroup_dataset"), 
       paste0(backups, "popgroup_dataset", Sys.Date()), 
       overwrite = TRUE
     )

--- a/data_preparation/update_popgroup_data.R
+++ b/data_preparation/update_popgroup_data.R
@@ -74,6 +74,9 @@ update_popgroup_data <- function(load_test_indicators = FALSE, create_backup = F
   # with the exception of IZs/HSC Localities where a parent area is also included i.e. 'HSC Locality/Edinburgh City/Edinburgh North-East'
   popgroup_dataset <- create_geography_path_column(popgroup_dataset)
   
+  # restrict to distinct rows (deals with situation if there are duplicates of the input files (or in these files): occurs in CWB)
+  popgroup_dataset <- popgroup_dataset |>
+    distinct() 
   
   # make available in global environment for viewing what will be sent to shiny app
   popgroup_dataset <<- popgroup_dataset

--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -50,8 +50,6 @@ geo_lookup <- setDT(geo_lookup)
 
 main_data_geo_nodes <- readRDS("data/main_dataset_geography_nodes.rds") # geography nodes for data table tab
 
-simd_dataset <- read_parquet("data/deprivation_dataset") # dataset behind simd panel
-
 techdoc <- read_parquet("data/techdoc") # technical document
 
 popgroup_dataset <- read_parquet("data/popgroup_dataset") # dataset behind popgroup panel

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -183,23 +183,10 @@ function(input, output, session) {
   rank_mod_server("rank", areatype_data, geo_selections)
   
   
-  # run the module containing the server logic for the  deprivation tab ONLY when specific profiles are selected, otherwise hide the tab
-  observe({
-    req(input$profile_choices != "")
-    if (profiles_list[[input$profile_choices]] %in% c("CWB", "HWB", "POP", "CYP", "MEN") & !is.null(profiles_list[[input$profile_choices]])) {
-      nav_show("sub_tabs", target = "simd_tab")
-      simd_navpanel_server("simd", simd_data, geo_selections)
-      
-    } else {
-      nav_hide("sub_tabs", target = "simd_tab")
-    }
-  })
-  
-
   # run the module that creates the server logic for the population groups tab ONLY when specific profiles are selected, otherwise hide the tab
   observe({
     req(input$profile_choices != "")
-    if (profiles_list[[input$profile_choices]] %in% c("CWB", "MEN") & !is.null(profiles_list[[input$profile_choices]])) {
+    if (profiles_list[[input$profile_choices]] %in% c("CWB", "HWB", "POP", "CYP", "MEN") & !is.null(profiles_list[[input$profile_choices]])) {
       nav_show("sub_tabs", target = "pop_groups_tab")
       pop_groups_server("pop_groups",popgroup_data, geo_selections)
     } else {
@@ -305,7 +292,7 @@ function(input, output, session) {
   
   
   # 2. MAIN DATASET FILTERED BY BOTH PROFILE AND AREATYPE
-  # used for rank/deprivation/summary tabs 
+  # used for rank/summary tabs 
   areatype_data <- reactive({
     req(profile_data())
     profile_data() |>
@@ -314,35 +301,15 @@ function(input, output, session) {
   
   
 
-
-  # 3. DEPRIVATION DATASET
-  # filters the deprivation dataset by selected profile, filtered data then passed to the depriavtion visualisation module 
-  simd_data <- reactive({
-    
-    req(profiles_list[[input$profile_choices]] %in% c("HWB", "CWB", "POP", "CYP", "MEN")) # only run when specific profiles have been selected
-
-    dt <- setDT(simd_dataset) # set to class data.table
-
-    # filter by selected geography as deprivation tab only displays info on a single area
-    dt <- dt[(areatype == geo_selections()$areatype | areatype == "Scotland") & areaname == geo_selections()$areaname]
-
-    # filter rows where profile abbreviation exists in one of the 3 profile_domain columns in the technical document
-    dt <- dt[substr(profile_domain1, 1, 3) == profiles_list[[input$profile_choices]] |
-               substr(profile_domain2, 1, 3) == profiles_list[[input$profile_choices]] |
-               substr(profile_domain3, 1, 3) == profiles_list[[input$profile_choices]]]
-  })
-
-
-
   # 4. POPULATION GROUPS DATASET
   # filters the population groups dataset by selected profile, filtered data then passed to the pop group visualisation module 
   popgroup_data <- reactive({
     
-    req(profiles_list[[input$profile_choices]] %in% c("CWB", "MEN")) # only run when specific profiles have been selected
+    req(profiles_list[[input$profile_choices]] %in% c("HWB", "CWB", "POP", "CYP", "MEN")) # only run when specific profiles have been selected
 
     dt <- setDT(popgroup_dataset) # set to class data.table
     
-    # filter by selected geography as deprivation tab only displays info on a single area
+    # filter by selected geography as popgroup tab only displays info on a single area
     dt <- dt[(areatype == geo_selections()$areatype | areatype == "Scotland") & areaname == geo_selections()$areaname]
     
     # filter rows where profile abbreviation exists in one of the 3 profile_domain columns in the technical document

--- a/shiny_app/ui.R
+++ b/shiny_app/ui.R
@@ -174,9 +174,6 @@ page_navbar(
                        # rank sub-tab 
                        nav_panel(title = "Rank", value = "rank_tab", rank_mod_ui("rank")),
                        
-                       # deprivation sub-tab 
-                       nav_panel(title = "Deprivation", value = "simd_tab", simd_navpanel_ui("simd")),
-                       
                        # population groups sub-tab
                        nav_panel(title = "Population groups", value = "pop_groups_tab", pop_groups_ui("pop_groups")),
                        nav_spacer(),


### PR DESCRIPTION
Contains a new function for combining deprivation and popgroup data, and changes to the popgroup tab so that SIMD can be included as a possible split, when available, and a second split filter (e.g. sex) can be selected if this is available. The SIMD tab has been removed.

The specifics of the new data format required are noted in the script combine_popgroup_and_simd_data.R, which contains the data-combining function that would now be run after the popgroup and deprivation datasets have been updated.

Currently the 2nd split is only used when SIMD is the 1st selected split, and only contains male/female/total. This is achieved by permitting the deprivation files that are read in to include an optional sex column. Future development would need to generalise this functionality if different 1st and 2nd splits were available. 

If this branch is OK new plots for RII, SII and PAR could be added to the popgroup tab (conditional on SIMD being selected as a split). 