### PR TITLE
VE_ filter with domain order

### DIFF
--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -99,12 +99,12 @@ archived_indicators <- techdoc$ind_id[techdoc$active == "AR"]
 # domain orders - some profiles require domains to be sorted in a specific order rather than the default behaviour which would sort them alphabetically
 # these domain orders are passed to Server script 
 
-CWB_domain_order <- c("Over-arching indicators","Early years","Education","Work","Living standards",
-                      "Healthy places", "Impact of ill health prevention","Discrimination and racism")
-MEN_domain_order <- c("Mental health outcomes", "Individual determinants",
-                      "Community determinants", "Structural determinants",
-                      "Male adult", "Female adult") # last two domains to be dropped once indicators reassigned elsewhere/archived
-CYP_domain_order <- c("Safe", "Healthy", "Achieving", "Nurtured", "Active", "Respected", "Responsible", "Included")
+# CWB_domain_order <- c("Over-arching indicators","Early years","Education","Work","Living standards",
+#                       "Healthy places", "Impact of ill health prevention","Discrimination and racism")
+# MEN_domain_order <- c("Mental health outcomes", "Individual determinants",
+#                       "Community determinants", "Structural determinants",
+#                       "Male adult", "Female adult") # last two domains to be dropped once indicators reassigned elsewhere/archived
+# CYP_domain_order <- c("Safe", "Healthy", "Achieving", "Nurtured", "Active", "Respected", "Responsible", "Included")
 
 
 

--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -96,6 +96,16 @@ profiles_list <- list(
 # into 'active' and 'archived' in the indicator filters across the other tabs
 archived_indicators <- techdoc$ind_id[techdoc$active == "AR"]
 
+# domain orders - some profiles require domains to be sorted in a specific order rather than the default behaviour which would sort them alphabetically
+# these domain orders are passed to Server script 
+
+CWB_domain_order <- c("Over-arching indicators","Early years","Education","Work","Living standards",
+                      "Healthy places", "Impact of ill health prevention","Discrimination and racism")
+MEN_domain_order <- c("Mental health outcomes", "Individual determinants",
+                      "Community determinants", "Structural determinants",
+                      "Male adult", "Female adult") # last two domains to be dropped once indicators reassigned elsewhere/archived
+CYP_domain_order <- c("Safe", "Healthy", "Achieving", "Nurtured", "Active", "Respected", "Responsible", "Included")
+
 
 
 # Area names by geography type  including HB, CA, HSCP, alcohol and drugs partnership

--- a/shiny_app/modules/visualisations/summary_table_mod.R
+++ b/shiny_app/modules/visualisations/summary_table_mod.R
@@ -130,7 +130,7 @@ summary_table_server <- function(id, selected_geo, selected_profile, filtered_da
       # Arrange by 'domain'
       chosen_area <- setorder(chosen_area, domain)
       
-      if(is.null(domain_order)) {
+      if(is.null(domain_order())) {
         
         # Arrange by 'domain'
         chosen_area <- setorder(chosen_area, domain)
@@ -138,7 +138,7 @@ summary_table_server <- function(id, selected_geo, selected_profile, filtered_da
       } else {
         
         # arrange by 'domain' with custom sort order
-        chosen_area <- chosen_area[, domain := factor(domain, levels = domain_order)]
+        chosen_area <- chosen_area[, domain := factor(domain, levels = domain_order())]
         chosen_area <- setorder(chosen_area, domain)
         
       }
@@ -252,14 +252,14 @@ summary_table_server <- function(id, selected_geo, selected_profile, filtered_da
       # set domain column as the first in the table
       setcolorder(dt, "domain")
       
-      if(is.null(domain_order)) {
+      if(is.null(domain_order())) {
       
       # Arrange by 'domain'
       dt <- setorder(dt, domain)
       
       } else {
         
-      dt <- dt[, domain := factor(domain, levels = domain_order)]
+      dt <- dt[, domain := factor(domain, levels = domain_order())]
       dt <- setorder(dt, domain)
         
       }

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -88,7 +88,7 @@ function(input, output, session) {
   
   
   # create reactive value that contains the domain ordering   
-  profile_domain_order <- reactiveVal(
+  profile_domain_order <- reactive({
     
     if(input$profile_choices == "CWP"){
       c("Over-arching indicators","Early years","Education","Work","Living standards",
@@ -103,7 +103,7 @@ function(input, output, session) {
       
     } else{
       NULL
-    }
+    }}
   )
 
   
@@ -176,37 +176,37 @@ function(input, output, session) {
   #######################################################################.
   
   # run the module containing server logic for the trends tab - this is visible for every single profile 
-  trend_mod_server("trends", profile_data, geo_selections, reactive({input$profile_choices}))
+  #trend_mod_server("trends", profile_data, geo_selections, reactive({input$profile_choices}))
   
   
   # run the module containing server logic for the  rank tab - this is visible for every single profile
-  rank_mod_server("rank", areatype_data, geo_selections)
+#  rank_mod_server("rank", areatype_data, geo_selections)
   
   
   # run the module containing the server logic for the  deprivation tab ONLY when specific profiles are selected, otherwise hide the tab
-  observe({
-    req(input$profile_choices != "")
-    if (profiles_list[[input$profile_choices]] %in% c("CWB", "HWB", "POP", "CYP", "MEN") & !is.null(profiles_list[[input$profile_choices]])) {
-      nav_show("sub_tabs", target = "simd_tab")
-      simd_navpanel_server("simd", simd_data, geo_selections)
-      
-    } else {
-      nav_hide("sub_tabs", target = "simd_tab")
-    }
-  })
-  
+  # observe({
+  #   req(input$profile_choices != "")
+  #   if (profiles_list[[input$profile_choices]] %in% c("CWB", "HWB", "POP", "CYP", "MEN") & !is.null(profiles_list[[input$profile_choices]])) {
+  #     nav_show("sub_tabs", target = "simd_tab")
+  #     simd_navpanel_server("simd", simd_data, geo_selections)
+  #     
+  #   } else {
+  #     nav_hide("sub_tabs", target = "simd_tab")
+  #   }
+  # })
+  # 
 
   # run the module that creates the server logic for the population groups tab ONLY when specific profiles are selected, otherwise hide the tab
-  observe({
-    req(input$profile_choices != "")
-    if (profiles_list[[input$profile_choices]] %in% c("CWB", "MEN") & !is.null(profiles_list[[input$profile_choices]])) {
-      nav_show("sub_tabs", target = "pop_groups_tab")
-      pop_groups_server("pop_groups",popgroup_data, geo_selections)
-    } else {
-      nav_hide("sub_tabs", target = "pop_groups_tab")
-    }
-  })
-  
+  # observe({
+  #   req(input$profile_choices != "")
+  #   if (profiles_list[[input$profile_choices]] %in% c("CWB", "MEN") & !is.null(profiles_list[[input$profile_choices]])) {
+  #     nav_show("sub_tabs", target = "pop_groups_tab")
+  #     pop_groups_server("pop_groups",popgroup_data, geo_selections)
+  #   } else {
+  #     nav_hide("sub_tabs", target = "pop_groups_tab")
+  #   }
+  # })
+  # 
   
   
   # always default to the summary tab when user switches profile (unless all indicators has been selected as there is no summary for this - default to trends tab instead)


### PR DESCRIPTION
Sorry I had a mental short circuit when I created the branch and called it filter_with_filter (instead of domain) but i'm basically trying to find a neat way of getting domain order into the indicator selection filter.
Was attempting to make reactive object that detects which profile has been selected which contains the correct domain sort ordering that can be passed to both the summary tab module and the indicator filter module. 
Adding this kind of reactive object might be more efficient but perhaps slows down the loading of the pages - I started off with just static objects in the global script but then coudn't figure out how to get the indicator selection module to pick the correct domain ordering?
Perhaps looking at Liz's PR will also be sensible so you know what i'm aiming for. 