### PR TITLE
ER - tweaks to the deprivation data prep 

### DIFF
--- a/data_preparation/2_dataprep_functions.R
+++ b/data_preparation/2_dataprep_functions.R
@@ -46,8 +46,9 @@ combine_files <- function(file_list) {
   }
   
   
-  combined_data <- rbindlist(lapply(file_list, function(x) {
-    
+#  combined_data <- rbindlist(lapply(file_list, function(x) {
+  combined_data <- plyr::rbind.fill(lapply(file_list, function(x) {
+      
     # read in datafile
     data <- if (file_type == 'rds') readRDS(x) else fread(x)
     

--- a/data_preparation/update_deprivation_data.R
+++ b/data_preparation/update_deprivation_data.R
@@ -30,7 +30,8 @@ update_deprivation_data <- function(load_test_indicators = FALSE, create_backup 
     )
     
     ## Combine into one dataset  -----
-    test_deprivation_dataset <- combine_files(test_deprivation_files)
+    test_deprivation_dataset <- combine_files(test_deprivation_files) %>% 
+      mutate(numerator = as.numeric(numerator)) # in case NA in any data files has turned this column to character
     
     ## Combine main dataset and test indicators
     deprivation_dataset <- bind_rows(deprivation_dataset, test_deprivation_dataset)


### PR DESCRIPTION
Getting the deprivation data prep to work when input data can have a sex column (or not). Also a tweak to deal with NA numerators (which can be read in as character, making it difficult to combine them with numeric data). May be useful, might not...