### PR TITLE
amend deprivation data prep process

### DIFF
--- a/data_preparation/2_dataprep_functions.R
+++ b/data_preparation/2_dataprep_functions.R
@@ -56,13 +56,17 @@ combine_files <- function(file_list) {
     
     # add column that includes filename
     data$file_name <- basename(x)
+    
+    # make numerator column class numeric
+    data$numerator <- as.numeric(data$numerator)
+    
     #rename column
     colnames(data)[colnames(data) == 'rate'] <- 'measure'
     
     # clean column names 
     clean_names(data)
     
-  }), use.names = TRUE)
+  }), fill = TRUE)
   
   return(combined_data)
 }

--- a/data_preparation/update_deprivation_data.R
+++ b/data_preparation/update_deprivation_data.R
@@ -19,11 +19,6 @@ update_deprivation_data <- function(load_test_indicators = FALSE, create_backup 
   ## combine into one deprivation dataset
   deprivation_dataset <- combine_files(deprivation_files) #call to one of the generic functions that combines files from list
   
-  # replace NAs in sex column with Total
-  # these NAs are introduced when combining files where sex column not present and so auto-filled with NAs
-  deprivation_dataset$sex[is.na(deprivation_dataset$sex)] <- "Total"
-  
-  
   ## If test indicators are to be included then list files & combine files from test shiny folder
   if (load_test_indicators == TRUE){
     ## Find new indicators data files in the test shiny data folder -----
@@ -39,6 +34,10 @@ update_deprivation_data <- function(load_test_indicators = FALSE, create_backup 
     ## Combine main dataset and test indicators
     deprivation_dataset <- bind_rows(deprivation_dataset, test_deprivation_dataset)
   } #close test indicator function
+  
+  # replace NAs in sex column with Total
+  # these NAs are introduced when combining files where sex column not present and so auto-filled with NAs
+  deprivation_dataset$sex[is.na(deprivation_dataset$sex)] <- "Total"
   
   # for now skip loading andy pulford inequality indicators
   # attach technical document info ----

--- a/data_preparation/update_deprivation_data.R
+++ b/data_preparation/update_deprivation_data.R
@@ -19,11 +19,9 @@ update_deprivation_data <- function(load_test_indicators = FALSE, create_backup 
   ## combine into one deprivation dataset
   deprivation_dataset <- combine_files(deprivation_files) #call to one of the generic functions that combines files from list
   
-  ## TEMPORARY FIX - need to adjust data prep process
-  ## sex column not yet added to all inequalities indicator output files during data prep
-  ## need to add this columns with a value of 'Total' for indicators when its missing.
-  deprivation_dataset <-deprivation_dataset |>
-    mutate(sex = "Total")
+  # replace NAs in sex column with Total
+  # these NAs are introduced when combining files where sex column not present and so auto-filled with NAs
+  deprivation_dataset$sex[is.na(deprivation_dataset$sex)] <- "Total"
   
   
   ## If test indicators are to be included then list files & combine files from test shiny folder


### PR DESCRIPTION
@elizabeth-richardson thought it would be easier if I just quickly done this as your other PR wasn't up to date with master. There had been some other tweaks to data prep and I thought it might be more hassle for you to work out what whats!

This should fix the deprivation issue. Just set fill to TRUE when combining files so it doesn't matter if one dataset has a column that another doesn't. This ensures no issues when sex column is in one deprivation file and not another. This fills the sex column with NA for those files where it didn't exist, and we then just replace them with 'Total'. If we want to avoid rogue columns being loaded into the app due to this we can just be explicit about selecting columns before saving the file.

Let me know if this works for you. I'd imagine it won't work unless loading test files for now, since there are no files moved to the shiny folder yet with a sex column, so it will trip up when trying to replace values on a column that doesn't exist. This should sort itself out as soon as 1 file is moved over.