### PR TITLE
Data prep temporary fix (needed if loading the test data, in current state)

### DIFF
--- a/data_preparation/update_popgroup_data.R
+++ b/data_preparation/update_popgroup_data.R
@@ -37,7 +37,8 @@ update_popgroup_data <- function(load_test_indicators = FALSE, create_backup = F
     
     
     ## Combine into one dataset  -----
-    test_popgroup_dataset  <- combine_files(test_popgroup_data_files)
+    test_popgroup_dataset  <- combine_files(test_popgroup_data_files) %>%
+      mutate(trend_axis = as.character(trend_axis)) # TEMPORARY FIX IF THE DATA IN THE TEST FOLDER CAUSE TREND_AXIS TO BECOME INTEGER RATHER THAN CHAR
     
     ## Combine main dataset and test indicators
     popgroup_dataset<- bind_rows(popgroup_dataset, test_popgroup_dataset)


### PR DESCRIPTION
Temporary fix to incompatibility caused by file(s) in test folder having integer trend_axis. This allows test and non-test data to be appended successfully. Not an issue if test data not being loaded (or if some files in the test folder have character trend_axis columns)