### PR TITLE
ER - Improve SIMD chart messaging

### DIFF
--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -79,14 +79,15 @@ pd_bound <- sf::st_as_sf(pd_bound)
 profiles_list <- list(
   "Health and Wellbeing" = "HWB",
   "Care and Wellbeing" = "CWB",
-  "Children and Young People" = "CYP",
-  "Drugs" = "DRG",
-  "Alcohol" = "ALC",
-  "Population" = "POP",
-  "Tobacco" = "TOB",
   "Mental Health" = "MEN",
+  "Tobacco" = "TOB",
+  "Alcohol" = "ALC",
+  "Drugs" = "DRG",
+  "Children and Young People" = "CYP",
+  "Population" = "POP",
   "All Indicators" = "ALL"
   )
+
 
 # there are some profiles where the domains should be ordered in a particular way 
 # e.g. CWB profile should start with 'overarching indicators'

--- a/shiny_app/modules/visualisations/simd_mod.R
+++ b/shiny_app/modules/visualisations/simd_mod.R
@@ -584,7 +584,7 @@ simd_navpanel_ui <- function(id) {
         h5(chart_text()$left_chart_title, class = "chart-header"),
         h6(chart_text()$left_chart_subtitle_1),
         p(chart_text()$left_chart_subtitle_2),
-        actionLink("left_chart_info_link", label = "Learn more") # link to interpretation tab 
+        actionLink(ns("left_chart_info_link"), label = "Learn more") # link to interpretation tab 
       )
       }
     })
@@ -597,7 +597,7 @@ simd_navpanel_ui <- function(id) {
         h5(chart_text()$right_chart_title, class = "chart-header"),
         h6(chart_text()$right_chart_subtitle_1),
         p(chart_text()$right_chart_subtitle_2),
-        actionLink("right_chart_info_link", label = "Learn more") # link to interpretation tab 
+        actionLink(ns("right_chart_info_link"), label = "Learn more") # link to interpretation tab 
       )
       }
     })

--- a/shiny_app/modules/visualisations/simd_mod.R
+++ b/shiny_app/modules/visualisations/simd_mod.R
@@ -69,8 +69,7 @@ simd_navpanel_ui <- function(id) {
             nav_panel(
               title = "Chart",
               div(
-                uiOutput(ns("left_chart_header")), # chart header 
-                actionLink(ns("left_chart_info_link"), label = "Learn more") # link to interpretation tab 
+                uiOutput(ns("left_chart_header")) # chart header 
               ),
               highchartOutput(ns("left_chart")) |> # chart
                 # note this is the recommended way to add a chart spinner 
@@ -131,8 +130,7 @@ simd_navpanel_ui <- function(id) {
             nav_panel(
               title = "Chart",
               div(
-                uiOutput(ns("right_chart_header")),
-                actionLink(ns("right_chart_info_link"), label = "Learn more")
+                uiOutput(ns("right_chart_header"))
               ),
               highchartOutput(ns("right_chart")) |>
                 # note this is the recommended way to add a chart spinner 
@@ -580,34 +578,40 @@ simd_navpanel_ui <- function(id) {
     
     # render the title and subtitle for the left hand side card
     output$left_chart_header <- renderUI({
-      shiny::validate(need(nrow(indicator_data()) > 0, "No indicators available")) # display custom message if no data available
-      div(
+
+      if(nrow(indicator_data()) > 0) {
+        div(
         h5(chart_text()$left_chart_title, class = "chart-header"),
         h6(chart_text()$left_chart_subtitle_1),
-        p(chart_text()$left_chart_subtitle_2)
+        p(chart_text()$left_chart_subtitle_2),
+        actionLink("left_chart_info_link", label = "Learn more") # link to interpretation tab 
       )
+      }
     })
     
     # render the title and subtitle for the right hand side card
     output$right_chart_header <- renderUI({
-      shiny::validate(need(nrow(indicator_data()) > 0, "No indicators available")) # display custom message if no data available
-      div(
+  
+      if(nrow(indicator_data()) > 0) {
+        div(
         h5(chart_text()$right_chart_title, class = "chart-header"),
         h6(chart_text()$right_chart_subtitle_1),
-        p(chart_text()$right_chart_subtitle_2)
+        p(chart_text()$right_chart_subtitle_2),
+        actionLink("right_chart_info_link", label = "Learn more") # link to interpretation tab 
       )
+      }
     })
     
     
-    # render the narrative for left cards interpretation tab 
+    # render the narrative for left cards interpretation tab
     output$left_chart_narrative <- renderUI({
-      chart_text()$left_chart_narrative
+        chart_text()$left_chart_narrative
     })
-    
+
     # render the narrative for the right cards interpretation tab
     output$right_chart_narrative <- renderUI({
-      chart_text()$right_chart_narrative
-    }) 
+        chart_text()$right_chart_narrative
+    })
     
     
     #######################################.
@@ -619,9 +623,12 @@ simd_navpanel_ui <- function(id) {
     output$left_chart <- renderHighchart({
       
       # only create charts if there is data available to plot
+      # validation message suggests the other two area types the user might try (although dep data aren't necessarily available at the lower geog: should the message only suggest available geogs?)
       shiny::validate(
         need(nrow(indicator_data()) > 0,
-             paste0("SIMD data is not available at ", geo_selections()$areatype, " level. Please select either Scotland, Health board or Council area."))
+             paste0("Deprivation data are not available at ", geo_selections()$areatype, " level in this profile. Please try a different geography, of either ", 
+                    paste(setdiff(c("Scotland", "Health board", "Council area"), geo_selections()$areatype), collapse = " or "), 
+                    "."))
       )
       
       
@@ -683,7 +690,9 @@ simd_navpanel_ui <- function(id) {
       # only create charts if there is data available to plot
       shiny::validate(
         need(nrow(indicator_data()) > 0,
-             paste0("SIMD data is not available at ", geo_selections()$areatype, " level. Please select either Scotland, Health board or Council area."))
+             paste0("Deprivation data are not available at ", geo_selections()$areatype, " level in this profile. Please try a different geography, of either ", 
+                    paste(setdiff(c("Scotland", "Health board", "Council area"), geo_selections()$areatype), collapse = " or "), 
+                    "."))
       )
       
       


### PR DESCRIPTION
**Response to Jaime's comment last week. Could this be addressed with a redeploy? I'd like to publicise the mental health profile to interested parties, but predict they'll also see this as an error.**

The 'no data' messaging on the SIMD charts was confusing, particularly (or only?) for the mental health profile. Here SIMD data are only available at Scotland level, currently. A user could select health boards and be told there are no SIMD data, so why don't you select health boards (or Scotland/council areas). There was also a ' Learn more' link for more info, which from its inclusion here looked like it would be explaining why there was no data, but instead took the user to the tab explaining what they were seeing in the (non-existent) chart. 

This PR removes the 'Learn more' link if there is no data to display, and makes the no data message clearer. It suggests that the user tries one of the other two geog types. It is possible (or a certainty in the mental health profile, currently) that one of the suggested geog types will also not have SIMD data, but that will lead them to select Scotland eventually. 

I thought about having the 'no data' message suggest only the geog types for which SIMD data were available for that profile, but   think that could get tricky (some indicators might have differing geographical availability).