### PR TITLE
remove logic to exclude globally selected geography as filter choice

### DIFF
--- a/shiny_app/modules/visualisations/trend_mod.R
+++ b/shiny_app/modules/visualisations/trend_mod.R
@@ -259,30 +259,6 @@ trend_mod_server <- function(id, filtered_data, geo_selections, selected_profile
     
 
     
-    # remove globally selected areaname from available areas in dropdowns
-    observe({
-      if(geo_selections()$areatype == "Health board"){
-        updateSelectizeInput(session, "hb_filter", choices = hb_list[hb_list!=geo_selections()$areaname])
-      }
-      else if(geo_selections()$areatype == "Council area"){
-        updateSelectizeInput(session, "ca_filter", choices = ca_list[ca_list!=geo_selections()$areaname])
-      }
-      else if(geo_selections()$areatype == "HSC partnership"){
-        updateSelectizeInput(session, "hscp_filter", choices = hscp_list[hscp_list!=geo_selections()$areaname])
-      }
-      else if(geo_selections()$areatype == "Alcohol & drug partnership"){
-        updateSelectizeInput(session, "adp_filter", choices = adp_list[adp_list!=geo_selections()$areaname])
-      }
-      else if(geo_selections()$areatype %in% c("Intermediate zone", "HSC locality")){
-        updateSelectizeInput(session, "hscp_filter_2", selected = geo_selections()$parent_area)
-      }
-      else if(geo_selections()$areatype == "Police division"){
-        updateSelectizeInput(session, "pd_filter", choices = pd_list[pd_list!=geo_selections()$areaname])
-      }
-      
-    })
-    
-    
     # Clear what was previously selected from the filters if a user changes selection from geography filter (otherwise they remain selected)
     observeEvent(geo_selections(), {
       


### PR DESCRIPTION
Hi both, 

Just removing a bit of logic from the trends tab, following an email in the scotpho mailbox. Currently, any global geography selections are excluded from the filters in the trends tab. For instance, if you have NHS Tayside selected globally, it won't be an option in the trend tabs health board filter. 

However, there is an issue which only occurs under a very specific circumstance! If you select a local area from the global filter (resulting in it being removed as a trend filter option), then select another geography globally, the previous global geography selection is not added back in as an option in the trend tab.

I can't imagine this is an issue many have experienced. You'd need to be wanting to select an area in the trend tab that you previously had selected from the global filter. However, removing the bit of code that excludes a globally selected geography as an option to fix this. It does mean it will always appear as an option in the trend tab filters, but I don't think that's an issue. If users select it nothing would happen anyway since their globally selected geography will always be pre-selected and appear in the trend chart itself, so I don't think anyone would have reason to select it anyway.

