### PR TITLE
ER - add profile list

### DIFF
--- a/data_preparation/update_techdoc.R
+++ b/data_preparation/update_techdoc.R
@@ -67,8 +67,9 @@ update_techdoc <- function(load_test_indicators=FALSE, create_backup=FALSE) {
   technical_doc <<- technical_doc |>
     select(
       ind_id, indicator_name, type_id, interpret, supression,
-      supress_less_than, type_definition, profile_domain1,
-      profile_domain2, profile_domain3, label_inequality
+      supress_less_than, type_definition, 
+     # profile_domain1, profile_domain2, profile_domain3, 
+      label_inequality, profile_list
     )
   
   

--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -98,7 +98,7 @@ profiles_list <- list(
 # If a profile does not have an domain ordering supplied domains and indicators will sort alphbetically.
 
 profile_domain_order <- list(
-  "Care and Wellbeing" = c("Over-arching indicators","Early years","Education","Work","Living standards",
+  "Care and Wellbeing" = c("Overarching indicators","Early years","Education","Work","Living standards",
                            "Healthy places", "Impact of ill health prevention","Discrimination and racism"),
   "Mental Health" =  c("Mental health outcomes", "Individual determinants",
                        "Community determinants", "Structural determinants"),

--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -222,18 +222,26 @@ prepare_profile_data <- function(dataset, # a dataset (e.g. main,simd or pop_grp
   }
   
   # within the technical document indicator can be assigned to one or more profile
-  # filter rows where profile abbreviation exists in one of the 3 profile_domain columns in the technical document
-dt <- dt[substr(profile_domain1, 1, 3) == profiles_list[[selected_profile]] |
-             substr(profile_domain2, 1, 3) == profiles_list[[selected_profile]] |
-             substr(profile_domain3, 1, 3) == profiles_list[[selected_profile]]]
+  # # filter rows where profile abbreviation exists in one of the 3 profile_domain columns in the technical document
+  # dt <- dt[substr(profile_domain1, 1, 3) == profiles_list[[selected_profile]] |
+  #            substr(profile_domain2, 1, 3) == profiles_list[[selected_profile]] |
+  #            substr(profile_domain3, 1, 3) == profiles_list[[selected_profile]]]
+  # NEW: filter if the XXX profile code is found in the profiles_list column
+  dt <- dt[grepl(paste0(profiles_list[[selected_profile]], "-"), profile_list)]
+  
 
   #create a domain column - this ensures we return the correct domain for the chosen profile in cases where an indicator
   # is assigned to more than one profile (and therefore more than one domain)
-  dt <- dt[, domain := fifelse(substr(profile_domain1, 1, 3) == profiles_list[[selected_profile]],
-                             substr(profile_domain1, 5, nchar(as.vector(profile_domain1))),
-                             fifelse(substr(profile_domain2, 1, 3) == profiles_list[[selected_profile]],
-                                     substr(profile_domain2, 5, nchar(as.vector(profile_domain2))),
-                                     substr(profile_domain3, 5, nchar(as.vector(profile_domain3)))))]
+  # dt <- dt[, domain := fifelse(substr(profile_domain1, 1, 3) == profiles_list[[selected_profile]],
+  #                            substr(profile_domain1, 5, nchar(as.vector(profile_domain1))),
+  #                            fifelse(substr(profile_domain2, 1, 3) == profiles_list[[selected_profile]],
+  #                                    substr(profile_domain2, 5, nchar(as.vector(profile_domain2))),
+  #                                    substr(profile_domain3, 5, nchar(as.vector(profile_domain3)))))]
+  # NEW: This code extracts the relevant profile and domain (it looks for the text after the XXX profile code and stops if a character that isn't a letter or a space is encountered, e.g., a ";")
+  dt <- dt[, domain := regmatches(profile_list, 
+                                  regexpr(paste0(profiles_list[[selected_profile]], "-([a-zA-Z*[[:blank:]]]*)*"), 
+                                          profile_list))
+  ][, domain := substr(domain, 5, nchar(domain))] # gets rid of the XXX profile code
   
 dt #returns a data table filtered to only contain indicators belonging to selected profile with column added for correct domain
   


### PR DESCRIPTION
Motivated by indicators appearing in more than 3 profiles, I added a profile_list column to the techdoc, with the usual XXX-Domain strings concatenated into a list separated by a semi-colon. (I don't think it matters if the list ends with a semi-colon or not, but will check later). The update_techdoc script keeps the new column and drops the previous 3 that aren't needed now. The prepare_profile_data() function in the global script uses the new column to filter the data for the required profile, and adds a column with the relevant domain name.  