### PR TITLE
Mm remove temporary workarounds

### DIFF
--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -12,7 +12,6 @@ library(phsstyles) # for phs colour palette
 library(shinyjs) # for various functions to expand/collapse geography filters 
 library(htmltools) # for landing page template to read
 library(purrr) # needed for sourcing modules with map
-library(arrow) # for reading parquet files
 library(reactable) # data tables
 library(highcharter) # visualisations
 library(data.table) # faster data wrangling

--- a/shiny_app/modules/visualisations/data_table_tab_mod.R
+++ b/shiny_app/modules/visualisations/data_table_tab_mod.R
@@ -15,6 +15,8 @@ data_tab_modUI <- function(id) {
   tagList(
     page_sidebar(padding = 20, gap = 20,
                        sidebar = sidebar(width = 300, padding = 20,
+                                         open = list(mobile = "always-above"), # make contents of side collapse on mobiles above main content
+                                         
                                          # clear filters button
                                          actionButton(ns("clear_table_filters"),
                                                       label = "Clear all filters",

--- a/shiny_app/modules/visualisations/pop_groups_mod.R
+++ b/shiny_app/modules/visualisations/pop_groups_mod.R
@@ -16,6 +16,8 @@ pop_groups_ui <- function(id) {
     layout_sidebar(
       # sidebar for filters ----
       sidebar = sidebar(width = 300,
+                        open = list(mobile = "always-above"), # make contents of side collapse on mobiles above main content
+                        
                         
                         # indicator filter (note this is a module)
                         indicator_filter_mod_ui(ns("indicator_filter")),

--- a/shiny_app/modules/visualisations/pop_groups_mod.R
+++ b/shiny_app/modules/visualisations/pop_groups_mod.R
@@ -43,9 +43,8 @@ pop_groups_ui <- function(id) {
             bslib::nav_panel("Chart",
                              uiOutput(ns("pop_rank_title")), # title 
                              highchartOutput(ns("pop_rank_chart")) |> # chart 
-                               withSpinner() |> (\(x) {
-                                 x[[4]] <- x[[4]] |> bslib::as_fill_carrier() 
-                                 x})()
+                               withSpinner() |> 
+                               bslib::as_fill_carrier() 
             ),
             
             # tab 2: data table
@@ -89,9 +88,9 @@ pop_groups_ui <- function(id) {
             bslib::nav_panel("Chart",
                              uiOutput(ns("pop_trend_title")), # title
                              highchartOutput(ns("pop_trend_chart")) |> # chart
-                               withSpinner() |> (\(x) {
-                                 x[[4]] <- x[[4]] |> bslib::as_fill_carrier() 
-                                 x})()
+                               withSpinner() |> 
+                               bslib::as_fill_carrier() 
+
             ),
             # tab 2: data table 
             bslib::nav_panel("Table",

--- a/shiny_app/modules/visualisations/pop_groups_mod.R
+++ b/shiny_app/modules/visualisations/pop_groups_mod.R
@@ -35,12 +35,6 @@ pop_groups_ui <- function(id) {
         1/2,
         
         # Bar chart card ----
-
-        # footer with download buttons
-        # NOTE: the 'footer' argument for navset_card_pill() is currently not working
-        # package maintainers are aware and working on a fix
-        # using the card_footer argument for card() in the meantime and suppressing warnings until bug fixed
-        suppressWarnings(
           bslib::navset_card_pill(
             height = 600,
             full_screen = TRUE,
@@ -49,7 +43,9 @@ pop_groups_ui <- function(id) {
             bslib::nav_panel("Chart",
                              uiOutput(ns("pop_rank_title")), # title 
                              highchartOutput(ns("pop_rank_chart")) |> # chart 
-                               withSpinner() |> bslib::as_fill_carrier()
+                               withSpinner() |> (\(x) {
+                                 x[[4]] <- x[[4]] |> bslib::as_fill_carrier() 
+                                 x})()
             ),
             
             # tab 2: data table
@@ -76,15 +72,15 @@ pop_groups_ui <- function(id) {
             ),
             
             # card footer - download buttons
-            card_footer(class = "d-flex justify-content-left",
+            footer = card_footer(class = "d-flex justify-content-left",
                         download_chart_mod_ui(ns("save_pop_rankchart")),
                         download_data_btns_ui(ns("pop_rank_download")))
-          )), # close bar chart card
+
+          ), # close bar chart card
         
         
         ######  based on deprivation trend card addeded "pop_" to distinguish the two
 
-        suppressWarnings(
           bslib::navset_card_pill(
             height = 600,
             full_screen = TRUE,
@@ -93,7 +89,9 @@ pop_groups_ui <- function(id) {
             bslib::nav_panel("Chart",
                              uiOutput(ns("pop_trend_title")), # title
                              highchartOutput(ns("pop_trend_chart")) |> # chart
-                               withSpinner() |> bslib::as_fill_carrier()
+                               withSpinner() |> (\(x) {
+                                 x[[4]] <- x[[4]] |> bslib::as_fill_carrier() 
+                                 x})()
             ),
             # tab 2: data table 
             bslib::nav_panel("Table",
@@ -114,11 +112,10 @@ pop_groups_ui <- function(id) {
               )
             ),
             # card footer - download buttons
-            card_footer(class = "d-flex justify-content-left",
+            footer = card_footer(class = "d-flex justify-content-left",
                         download_chart_mod_ui(ns("save_pop_trendchart")),
                         download_data_btns_ui(ns("pop_trend_download")))
-          )
-        ) # close trend card
+          )# close trend card
       ) # close layout column wrap
       
     ) # close sidebar layout

--- a/shiny_app/modules/visualisations/pop_groups_mod.R
+++ b/shiny_app/modules/visualisations/pop_groups_mod.R
@@ -32,7 +32,7 @@ pop_groups_ui <- function(id) {
       
       
       layout_column_wrap(
-        1/2,
+        width = 1/2,
         
         # Bar chart card ----
           bslib::navset_card_pill(

--- a/shiny_app/modules/visualisations/rank_charts_mod.R
+++ b/shiny_app/modules/visualisations/rank_charts_mod.R
@@ -81,9 +81,8 @@ rank_mod_ui <- function(id) {
                       value = ns("rank_chart_tab"), #id for guided tour
                       uiOutput(ns("rank_title")), # title
                       highchartOutput(ns("rank_chart")) |> # chart
-                        withSpinner() |> (\(x) {
-                          x[[4]] <- x[[4]] |> bslib::as_fill_carrier() 
-                          x})()
+                        withSpinner() |> 
+                        bslib::as_fill_carrier() 
             ),
             
             # data tab
@@ -120,9 +119,8 @@ rank_mod_ui <- function(id) {
           height = 600,
           full_screen = TRUE,
           leafletOutput(ns("rank_map")) |> # map
-            withSpinner() |> (\(x) {
-              x[[4]] <- x[[4]] |> bslib::as_fill_carrier() 
-              x})()
+            withSpinner() |> 
+            bslib::as_fill_carrier() 
         ))
         
       ) # close layout column wrap

--- a/shiny_app/modules/visualisations/rank_charts_mod.R
+++ b/shiny_app/modules/visualisations/rank_charts_mod.R
@@ -71,10 +71,6 @@ rank_mod_ui <- function(id) {
       
       layout_column_wrap(
         # bar chart card ----------------------
-        # NOTE: the 'footer' argument for navset_card_pill() is currently not working
-        # package maintainers are aware and working on a fix
-        # using the card_footer argument for card() in the meantime and suppressing warnings until bug fixed
-        suppressWarnings(
           navset_card_pill(
             id = ns("rank_navset_card_pill"),
             full_screen = TRUE,
@@ -85,7 +81,9 @@ rank_mod_ui <- function(id) {
                       value = ns("rank_chart_tab"), #id for guided tour
                       uiOutput(ns("rank_title")), # title
                       highchartOutput(ns("rank_chart")) |> # chart
-                        withSpinner() |> bslib::as_fill_carrier()
+                        withSpinner() |> (\(x) {
+                          x[[4]] <- x[[4]] |> bslib::as_fill_carrier() 
+                          x})()
             ),
             
             # data tab
@@ -110,10 +108,10 @@ rank_mod_ui <- function(id) {
               )
             )
             ),
-            card_footer(class = "d-flex justify-content-left",
+            footer = card_footer(class = "d-flex justify-content-left",
                         div(id = ns("rank_download_chart"), download_chart_mod_ui(ns("save_rank_chart"))),
                         div(id = ns("rank_download_data"), download_data_btns_ui(ns("rank_download"))))
-          )),
+          ),
        
         # map card -------------------
         
@@ -122,7 +120,9 @@ rank_mod_ui <- function(id) {
           height = 600,
           full_screen = TRUE,
           leafletOutput(ns("rank_map")) |> # map
-            withSpinner() |> bslib::as_fill_carrier()
+            withSpinner() |> (\(x) {
+              x[[4]] <- x[[4]] |> bslib::as_fill_carrier() 
+              x})()
         ))
         
       ) # close layout column wrap

--- a/shiny_app/modules/visualisations/rank_charts_mod.R
+++ b/shiny_app/modules/visualisations/rank_charts_mod.R
@@ -23,6 +23,7 @@ rank_mod_ui <- function(id) {
 
       # sidebar for filters ------------------
       sidebar = sidebar(width = 300,
+                        open = list(mobile = "always-above"), # make contents of side collapse on mobiles above main content
                         
 
                         # indicator filter (note this is a module)

--- a/shiny_app/modules/visualisations/simd_mod.R
+++ b/shiny_app/modules/visualisations/simd_mod.R
@@ -59,7 +59,6 @@ simd_navpanel_ui <- function(id) {
       # Left hand side card 
       layout_column_wrap(
         1/2,
-        suppressWarnings(
           navset_card_pill(
             id = ns("left_card"),
             height = 650,
@@ -74,7 +73,9 @@ simd_navpanel_ui <- function(id) {
               highchartOutput(ns("left_chart")) |> # chart
                 # note this is the recommended way to add a chart spinner 
                 # to a chart being held inside a bslib card
-                withSpinner() |> bslib::as_fill_carrier()
+                withSpinner() |> (\(x) {
+                  x[[4]] <- x[[4]] |> bslib::as_fill_carrier() 
+                  x})()
             ),
             
             # Data tab 
@@ -110,15 +111,13 @@ simd_navpanel_ui <- function(id) {
             ),
             
             # card footer with download buttons
-            card_footer(
+            footer = card_footer(
               class = "d-flex justify-content-left",
               download_chart_mod_ui(ns("save_left_chart")),
               download_data_btns_ui(ns("save_left_data")))
-          )
-        ),
+          ),
         
         # right hand side card 
-        suppressWarnings(
           navset_card_pill(
             id = ns("right_card"),
             height = 650,
@@ -133,7 +132,9 @@ simd_navpanel_ui <- function(id) {
               highchartOutput(ns("right_chart")) |>
                 # note this is the recommended way to add a chart spinner 
                 # to a chart being held inside a bslib card
-                withSpinner() |> bslib::as_fill_carrier()
+                withSpinner() |> (\(x) {
+                  x[[4]] <- x[[4]] |> bslib::as_fill_carrier() 
+                  x})()
             ),
             
             # data tab 
@@ -161,12 +162,11 @@ simd_navpanel_ui <- function(id) {
             ),
             
             # card footer with download buttons
-            card_footer(
+            footer = card_footer(
               class = "d-flex justify-content-left",
               download_chart_mod_ui(ns("save_right_chart")),
               download_data_btns_ui(ns("save_right_data")))
           )
-        )
       )
     )
   )

--- a/shiny_app/modules/visualisations/simd_mod.R
+++ b/shiny_app/modules/visualisations/simd_mod.R
@@ -58,7 +58,7 @@ simd_navpanel_ui <- function(id) {
       
       # Left hand side card 
       layout_column_wrap(
-        1/2,
+        width = 1/2,
           navset_card_pill(
             id = ns("left_card"),
             height = 650,

--- a/shiny_app/modules/visualisations/simd_mod.R
+++ b/shiny_app/modules/visualisations/simd_mod.R
@@ -16,6 +16,7 @@ simd_navpanel_ui <- function(id) {
       
       # sidebar for filters -----
       sidebar = sidebar(width = 300,
+                        open = list(mobile = "always-above"), # make contents of side collapse on mobiles above main content
                         
                         # indicator filter (note this is a module)
                         div(id = ns("deprivation_indicator_filter_wrapper"), indicator_filter_mod_ui(ns("simd_indicator_filter"))),

--- a/shiny_app/modules/visualisations/simd_mod.R
+++ b/shiny_app/modules/visualisations/simd_mod.R
@@ -71,11 +71,8 @@ simd_navpanel_ui <- function(id) {
                 uiOutput(ns("left_chart_header")) # chart header 
               ),
               highchartOutput(ns("left_chart")) |> # chart
-                # note this is the recommended way to add a chart spinner 
-                # to a chart being held inside a bslib card
-                withSpinner() |> (\(x) {
-                  x[[4]] <- x[[4]] |> bslib::as_fill_carrier() 
-                  x})()
+                withSpinner() |> 
+                bslib::as_fill_carrier() 
             ),
             
             # Data tab 
@@ -130,11 +127,8 @@ simd_navpanel_ui <- function(id) {
                 uiOutput(ns("right_chart_header"))
               ),
               highchartOutput(ns("right_chart")) |>
-                # note this is the recommended way to add a chart spinner 
-                # to a chart being held inside a bslib card
-                withSpinner() |> (\(x) {
-                  x[[4]] <- x[[4]] |> bslib::as_fill_carrier() 
-                  x})()
+                withSpinner() |> 
+                bslib::as_fill_carrier() 
             ),
             
             # data tab 

--- a/shiny_app/modules/visualisations/trend_mod.R
+++ b/shiny_app/modules/visualisations/trend_mod.R
@@ -92,9 +92,8 @@ trend_mod_ui <- function(id) {
                   uiOutput(ns("trend_title")), # title 
                   uiOutput(ns("trend_caveats")), # caveats
                   highchartOutput(outputId = ns("trend_chart")) |> # chart
-                    withSpinner() |> (\(x) {
-                      x[[4]] <- x[[4]] |> bslib::as_fill_carrier() 
-                      x})()
+                    withSpinner() |> 
+                    bslib::as_fill_carrier() 
         ), 
         
         # data tab ------------------

--- a/shiny_app/modules/visualisations/trend_mod.R
+++ b/shiny_app/modules/visualisations/trend_mod.R
@@ -21,6 +21,7 @@ trend_mod_ui <- function(id) {
       height = "80%",
       # sidebar for filters ------------------
       sidebar = sidebar(width = 500,
+                        open = list(mobile = "always-above"), # make contents of side collapse on mobiles above main content
                         accordion(
                           open = c("indicator_filter_panel", "geo_filter_panel"), # guided tour panel closed by default
                           multiple = TRUE, # allow multiple panels to be open at once

--- a/shiny_app/modules/visualisations/trend_mod.R
+++ b/shiny_app/modules/visualisations/trend_mod.R
@@ -237,7 +237,7 @@ trend_mod_server <- function(id, filtered_data, geo_selections, selected_profile
       # If 'Intermediate zone' is available, enable the filter otherwise disable it
       if("Intermediate zone" %in% available_areatypes){
         shinyjs::enable("iz_filter")
-        updateSelectizeInput(session, "iz_filter", choices = available_izs, options = list(placeholder = NULL), selected = iz_selections())
+        updateSelectizeInput(session, "iz_filter", choices = available_izs, options = list(placeholder = NULL), selected = iz_selections(), server = TRUE)
       } else {
         updateSelectizeInput(session, "iz_filter", options = list(placeholder = "Unavailable"), selected = character(0))
         shinyjs::disable("iz_filter")

--- a/shiny_app/modules/visualisations/trend_mod.R
+++ b/shiny_app/modules/visualisations/trend_mod.R
@@ -91,7 +91,10 @@ trend_mod_ui <- function(id) {
                   value = ns("trend_chart_tab"), #id for guided tour
                   uiOutput(ns("trend_title")), # title 
                   uiOutput(ns("trend_caveats")), # caveats
-                  highchartOutput(outputId = ns("trend_chart")) # chart
+                  highchartOutput(outputId = ns("trend_chart")) |> # chart
+                    withSpinner() |> (\(x) {
+                      x[[4]] <- x[[4]] |> bslib::as_fill_carrier() 
+                      x})()
         ), 
         
         # data tab ------------------
@@ -126,10 +129,11 @@ trend_mod_ui <- function(id) {
         ),
         
         # footer with download buttons
-        card_footer(class = "d-flex justify-content-left",
+        footer = card_footer(class = "d-flex justify-content-left",
                     div(id = ns("trend_download_chart"), download_chart_mod_ui(ns("download_trends_chart"))),
                     div(id = ns("trend_download_data"), download_data_btns_ui(ns("download_trends_data"))))
-      )) # close navset card pill
+      )
+      ) # close navset card pill
     ) # close layout sidebar
   ) # close taglist
 } # close ui function 

--- a/shiny_app/narrative/about_profiles_narrative.R
+++ b/shiny_app/narrative/about_profiles_narrative.R
@@ -7,7 +7,6 @@
 
 about_cwb_text <- navset_pill_list(
   widths = c(3, 9),
-  br(),
   nav_panel("Overview",
   h3("Overview"),
   p("The Care & Wellbeing Profile is one source of data and intelligence to support the ambitions of the ",
@@ -62,7 +61,6 @@ about_cwb_text <- navset_pill_list(
 
 about_hwb_text <- navset_pill_list(
   widths = c(3, 9),
-  br(),
 nav_panel("Overview",
 h3("Overview"),
 p("The ScotPHO Health and Wellbeing profiles are designed to provide a broad picture of health in Scotland, highlight health and social inequalities and aim
@@ -88,7 +86,6 @@ br()
 
 about_cyp_text <- navset_pill_list(
   widths = c(3, 9),
-  br(),
   nav_panel("Overview",
   h5("Overview"),
   p("The Scottish Public Health Observatory (ScotPHO) Children and Young People’s Profile presents a wide range of data at national, local authority, NHS board, health & social care partnership and, where available, intermediate zone level.
@@ -123,7 +120,6 @@ about_cyp_text <- navset_pill_list(
 
 about_alc_text <- navset_pill_list(
   widths = c(3, 9),
-  br(),
   nav_panel("Overview",
   h3("Overview"),
   p("The Scottish Public Health Observatory (ScotPHO) Alcohol Profile presents a range of data at national, local authority, NHS board, health & social care partnership and, where available, intermediate zone level.
@@ -145,7 +141,6 @@ about_alc_text <- navset_pill_list(
 
 about_men_text <-  navset_pill_list(
   widths = c(3, 9),
-  br(),
   nav_panel("Overview",
   h3("Overview"),
   p("The Mental Health Profile is the result of Public Health Scotland's ",
@@ -180,7 +175,7 @@ about_men_text <-  navset_pill_list(
   br()
   ),
   nav_panel("Mental Health Profile for Children and Young People",
-  h5("Mental Health Profile for Children and Young People"),
+  h3("Mental Health Profile for Children and Young People"),
   p("The ",
     tags$a("children and young people's mental health indicator set", href = "https://publichealthscotland.scot/our-areas-of-work/health-and-wellbeing/prevention-of-mental-ill-health-and-improved-wellbeing/mental-health-indicators/children-and-young-people-mental-health-indicators/", target="_blank"),
     "includes 70 indicators grouped into six high-level \"domains\":"),

--- a/shiny_app/ui.R
+++ b/shiny_app/ui.R
@@ -24,18 +24,7 @@ page_navbar(
     use_cicerone(), # required for guided tours
     tags$script(src = "https://code.highcharts.com/highcharts.js"), # required for spinecharts
     tags$script(src = "https://rawgit.com/rowanwins/leaflet-easyPrint/gh-pages/dist/bundle.js"),# required for saving leaflet map as png (see this for more info: https://stackoverflow.com/questions/47343316/shiny-leaflet-easyprint-plugin)
-    includeCSS("www/styles.css"), # required to specify formatting (particularly of landing page)
-    # This piece of code is temporary and can be removed when the bslib package is next updated
-    # It prevents a random extra clickable link appearing on the right-hand side of the gear icon in each multi-tab card
-    # this all stems from an bug with card footers which has been fixed in the dev version of bslib
-    # but this fix is not yet available on the cran version
-      tags$script(HTML("
-      $(document).ready(function() {
-        $('.card-header-pills').each(function() {
-          $(this).find('.nav-link').last().remove();
-        });
-      });
-    "))
+    includeCSS("www/styles.css") # required to specify formatting (particularly of landing page)
     ),
 
   #######################################.

--- a/shiny_app/ui.R
+++ b/shiny_app/ui.R
@@ -14,10 +14,12 @@ page_navbar(
   fillable = FALSE, # controlling how items grow/shrink when browser different sizes
   window_title = "ScotPHO profiles",
   id = "nav", # id required for profile buttons - works with profile_homepage_btn_mod to control navigation
-  collapsible = TRUE, # collapse tabs on smaller screens
   lang = "en",
-  bg = phs_colours(colourname = "phs-purple"), # background navbar colour
   theme = phs_theme, # dashboard theme - defined in global script
+  navbar_options = navbar_options(
+    bg = phs_colours(colourname = "phs-purple"), # background navbar colour
+    collapsible = TRUE # collapse tabs on smaller screens
+  ),
   # place external scripts in footer argument to avoid warnings as recommended by package developers
   header = tags$head(
     useShinyjs(), # need to declare this to use functions from the shinyjs package, e.g. to show/hide parts of the UI


### PR DESCRIPTION
Hi both, 

Nothing much to check here, just including yous as reviewers for awareness. Removing some temporary bits of code no longer required as some packages have been updated with bug fixes. In short, make sure you update your bslib package to the latest (0.9.0) and shinycssloaders to the latest (1.1.0). You should also now see far less warnings in the console when running the app. Think this has highlighted that we should probably get renv implemented pretty soon!

More detailed explanation:

1. We had some temporary code due to a bug with the navset_card_pill() function. Basically, there's a 'footer' argument of navset_card_pill() which wasn't working so we were suppressing warnings that were appearing in the console, and we also had to add some temporary code in the UI script. The argument now works properly with latest version of bslib so all temporary code has been removed.

2. Abbie recently re-installed some packages which also meant her version of shinycssloaders updated to the latest version. Turns out switching to the latest version also means we no longer need the workaround we were using to add spinners to charts. Abbie already removed the workaround recently but I added it back in and removed it again trying to work out what was going on as I didn't have the latest version of the package, in case you're confused by the commits!

3. There was a few syntax errors in the 'Further information' sub-tab that some profiles have. Just the br() function being added in the wrong places to add space, which was causing warnings in the console.