### PR TITLE
Mm reduce file size

### DIFF
--- a/data_preparation/1_ScotPHO_profiles_data_preparation.R
+++ b/data_preparation/1_ScotPHO_profiles_data_preparation.R
@@ -28,7 +28,7 @@ library(openxlsx) # for reading in technical document / converting excel dates
 library(readr) # for reading csv files
 library(data.table) # for quickly combining multiple files
 #library(scales) # for re-scaling measures
-library(arrow) # for writing parquet files
+library(nanoparquet) # for writing parquet files
 library(janitor) # for cleaning column names
 library(assertthat) # for data validation tests
 library(purrr) # for copying multiple files at once

--- a/data_preparation/update_deprivation_data.R
+++ b/data_preparation/update_deprivation_data.R
@@ -89,7 +89,7 @@ update_deprivation_data <- function(load_test_indicators = FALSE, create_backup 
   
  
   #write parquet file to shiny app data folder
-  write_parquet(deprivation_dataset, "shiny_app/data/deprivation_dataset")
+  write_parquet(deprivation_dataset, "shiny_app/data/deprivation_dataset.parquet", compression = "zstd")
   
   
   ## Optional: Create backup of from local repo -----

--- a/data_preparation/update_deprivation_data.R
+++ b/data_preparation/update_deprivation_data.R
@@ -89,7 +89,7 @@ update_deprivation_data <- function(load_test_indicators = FALSE, create_backup 
   
  
   #write parquet file to shiny app data folder
-  write_parquet(deprivation_dataset, "shiny_app/data/deprivation_dataset.parquet", compression = "zstd")
+  write_parquet(deprivation_dataset, "shiny_app/data/deprivation_dataset", compression = "zstd")
   
   
   ## Optional: Create backup of from local repo -----

--- a/data_preparation/update_main_data.R
+++ b/data_preparation/update_main_data.R
@@ -143,7 +143,7 @@ main_dataset <- create_geography_path_column(main_dataset)
 main_dataset <<- main_dataset
 
 ## save final file to local repo
-write_parquet(main_dataset, "shiny_app/data/main_dataset.parquet", compression = "zstd")
+write_parquet(main_dataset, "shiny_app/data/main_dataset", compression = "zstd")
 
 ## Optional: Create backup of from local repo -----
 ## Usually would only want to create a backup if you intend to update live tool

--- a/data_preparation/update_main_data.R
+++ b/data_preparation/update_main_data.R
@@ -143,7 +143,7 @@ main_dataset <- create_geography_path_column(main_dataset)
 main_dataset <<- main_dataset
 
 ## save final file to local repo
-write_parquet(main_dataset, "shiny_app/data/main_dataset")
+write_parquet(main_dataset, "shiny_app/data/main_dataset.parquet", compression = "zstd")
 
 ## Optional: Create backup of from local repo -----
 ## Usually would only want to create a backup if you intend to update live tool

--- a/data_preparation/update_popgroup_data.R
+++ b/data_preparation/update_popgroup_data.R
@@ -79,7 +79,7 @@ update_popgroup_data <- function(load_test_indicators = FALSE, create_backup = F
   popgroup_dataset <<- popgroup_dataset
   
   ## save final file to local repo
-  write_parquet(popgroup_dataset, "shiny_app/data/popgroup_dataset.parquet", compression = "zstd")
+  write_parquet(popgroup_dataset, "shiny_app/data/popgroup_dataset", compression = "zstd")
   
   ## Optional: Create backup of from local repo -----
   ## Usually would only want to create a backup if you intend to update live tool

--- a/data_preparation/update_popgroup_data.R
+++ b/data_preparation/update_popgroup_data.R
@@ -79,7 +79,7 @@ update_popgroup_data <- function(load_test_indicators = FALSE, create_backup = F
   popgroup_dataset <<- popgroup_dataset
   
   ## save final file to local repo
-  write_parquet(popgroup_dataset, "shiny_app/data/popgroup_dataset")
+  write_parquet(popgroup_dataset, "shiny_app/data/popgroup_dataset.parquet", compression = "zstd")
   
   ## Optional: Create backup of from local repo -----
   ## Usually would only want to create a backup if you intend to update live tool

--- a/data_preparation/update_techdoc.R
+++ b/data_preparation/update_techdoc.R
@@ -19,7 +19,7 @@ update_techdoc <- function(load_test_indicators=FALSE, create_backup=FALSE) {
   # Save back needs to occur before column selections/data manipulations applied. 
   if (create_backup==TRUE){
     ## Optional - generate a techdoc backup - suggested to run only when deploying live shiny app otherwise this line can be skipped
-    write_parquet(technical_doc_raw, paste0(backups, "techdoc-", Sys.Date())) # version for backups folder
+    write_parquet(technical_doc_raw, paste0(backups, "techdoc-", Sys.Date(), ".parquet"), compression = "zstd") # version for backups folder
   } 
   
   
@@ -47,7 +47,7 @@ update_techdoc <- function(load_test_indicators=FALSE, create_backup=FALSE) {
   
   
   ## Save file -----
-  write_parquet(technical_doc, "shiny_app/data/techdoc") # version for local shiny app
+  write_parquet(technical_doc, "shiny_app/data/techdoc.parquet", compression = "zstd") # version for local shiny app
   
   
   ## DO WE USE PROFILE LOOKUP ANYWHERE? -COULD IT SAVE processing in the shiny app?

--- a/data_preparation/update_techdoc.R
+++ b/data_preparation/update_techdoc.R
@@ -19,7 +19,7 @@ update_techdoc <- function(load_test_indicators=FALSE, create_backup=FALSE) {
   # Save back needs to occur before column selections/data manipulations applied. 
   if (create_backup==TRUE){
     ## Optional - generate a techdoc backup - suggested to run only when deploying live shiny app otherwise this line can be skipped
-    write_parquet(technical_doc_raw, paste0(backups, "techdoc-", Sys.Date(), ".parquet"), compression = "zstd") # version for backups folder
+    write_parquet(technical_doc_raw, paste0(backups, "techdoc-", Sys.Date()), compression = "zstd") # version for backups folder
   } 
   
   

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -251,7 +251,7 @@ function(input, output, session) {
     }
   }) |>
     # cache the filtered dataset
-    # this results in improved performance if there's than 1 user looking at the same profile 
+    # this results in improved performance if there's more than 1 user looking at the same profile 
     bindCache(input$profile_choices)  
   
   

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -235,8 +235,7 @@ function(input, output, session) {
   ###################################################.
   
   # 1. MAIN DATASET FILTERED BY PROFILE
-  # searches for the abbreviated name of the selected profile across the 3 profile columns in the main dataset
-  # note: there are 3 profile columns because some indicators belong to more than 1 profile 
+  # searches for the abbreviated name of the selected profile across the profile_domain column
   # if 'all indicators' is selected then entire dataset is used instead
   # this dataset is passed to the trends tab module
   # it's also used to create a smaller dataset which further filters by selected areatype
@@ -250,7 +249,10 @@ function(input, output, session) {
         selected_profile = input$profile_choices
       )
     }
-  })
+  }) |>
+    # cache the filtered dataset
+    # this results in improved performance if there's than 1 user looking at the same profile 
+    bindCache(input$profile_choices)  
   
   
   


### PR DESCRIPTION
Setting 'compression = "zstd"' when saving our datasets are parquet files reduces the file size, e.g. main_dataset has gone from 17MB to 11MB. Just adding in as will help as the datasets grow.

Also adding 'caching' to the reactive dataset that filters the main_dataset by selected profile. This means that if for example one person comes on the app and selects 'health and wellbeing', a filtered HWB dataset is cached and ready to be used by other users also exploring that profile at the same time, so the code doesn't need to be re-run and more memory isn't taken up. e.g. if there's 10 people looking at the same profile, the app would typically create 10 'copies' of the filtered dataset. This prevents that from happening.