### PR TITLE
Mm fix issues

### DIFF
--- a/shiny_app/modules/visualisations/rank_charts_mod.R
+++ b/shiny_app/modules/visualisations/rank_charts_mod.R
@@ -325,10 +325,8 @@ rank_mod_server <- function(id, profile_data, geo_selections, selected_profile) 
       )
       
       # further filter if HSCL or IZ selected, 
-      if(geo_selections()$areatype == "HSC locality"){
+      if(geo_selections()$areatype %in% c("HSC locality", "Intermediate zone")){
         x <- x |> filter(parent_area == geo_selections()$parent_area)
-      } else if(geo_selections()$areatype == "Intermediate zone"){
-        x <- x |> filter(council == geo_selections()$parent_area)
       } else{ 
         x
       }

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -259,7 +259,7 @@ function(input, output, session) {
   areatype_data <- reactive({
     req(profile_data())
     profile_data() |>
-      filter(areatype == input$areatype | areatype == "Scotland")
+      filter(areatype == geo_selections()$areatype | areatype == "Scotland")
   })
   
   
@@ -276,8 +276,8 @@ function(input, output, session) {
     prepare_profile_data(
       dataset = simd_dataset,
       selected_profile = input$profile_choices,
-      selected_areatype = input$areatype,
-      selected_areaname = input$areaname
+      selected_areatype = geo_selections()$areatype,
+      selected_areaname = geo_selections()$areaname
     )}
   })
   
@@ -290,8 +290,8 @@ function(input, output, session) {
     prepare_profile_data(
       dataset = popgroup_dataset,
       selected_profile = input$profile_choices,
-      selected_areatype = input$areatype,
-      selected_areaname = input$areaname
+      selected_areatype = geo_selections()$areatype,
+      selected_areaname = geo_selections()$areaname
     )
   })
 


### PR DESCRIPTION
2 issues have been fixed here:

1. The datasets were being filtered whenever a user changed geography rather than when the button was clicked. This was my mistake and only creeped in within last few weeks. Issue resolved here by using geo_selections() object which stores what geography user has selected only when button clicked, rather than filtering directly using the input ids of the geography filters which update instantly.

2. There's been an issue with our IZ shapefile. It had a council area column in it rather a HSPC column, which is what we use as our parent areas in the dataset/geography filters. This has been causing the app to crash if a user selected Edinburgh City or Western Isles as the parent area, because they don't exist in the IZ shapefile (well technically they do but annoyingly those councils are spelled differently than the equivalent HSCPs). It also meant it crashed if Clackmannanshire & Stirling was selected as the parent area since they are separate councils. I've created a new IZ shapefile with HSCPs instead of councils, so this should be picked up from the lookups folder when people re-run data prep scripts. The change in the app is just that the column in the IZ shapefile is now called parent_area rather than council, so just changing the name of the column to filter by.
