### PR TITLE
Ve cwp launch

### DIFF
--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -105,9 +105,10 @@ profiles_list <- list(
   ),
 
   # Care & wellbeing portfolio info 
-  "Care & Wellbeing Portfolio" = list(
+  "Population Health" = list(
     short_name = "CWB",
-    homepage_description = markdown("View indicators relating to **Population health**, **Inequalities** and **Wider determinants** (part of the Scottish Government's Care and Wellbeing Portfolio)."),
+    homepage_description = markdown("View indicators through the lens of the **Marmot principles**. Supporting Scotland's **Population Health Framework**, and 
+                                    the **Collaboration for Health Equity in Scotland**"),
     domain_order = c("Over arching indicators","Early years","Education","Work","Living standards",
                      "Healthy places", "Impact of ill health prevention","Discrimination and racism", "Environmental sustainability and health equity"),
     subtabs = all_subtabs,
@@ -185,7 +186,7 @@ profiles_list <- list(
     short_name = "ALL",
     homepage_description = markdown("View **all indicators** in this tool from across every profile."),
     domain_order = NULL,
-    subtabs = c("trends_tab", "rank_tab", "simd_tab"),
+    subtabs = all_subtabs,
     active = TRUE
   ),
   

--- a/shiny_app/narrative/about_profiles_narrative.R
+++ b/shiny_app/narrative/about_profiles_narrative.R
@@ -3,59 +3,186 @@
 ###########################################.
 
 ###########################################.
-### Care and Wellbeing ----
+### Population Health (formerly Care and Wellbeing) ----
 
 about_cwb_text <- navset_pill_list(
   widths = c(3, 9),
-  nav_panel("Overview",
-  h3("Overview"),
-  p("The Care & Wellbeing Profile is one source of data and intelligence to support the ambitions of the ",
-    tags$a("Care & Wellbeing Portfolio (CWP)", href = "https://www.gov.scot/groups/care-and-wellbeing-portfolio-board/", target = "_blank"),
-    "to improve population health, address health inequalities and improve
-     the health and care system."),
-  p("Many of the influences on health outcomes lie outwith health and social care.
-     Collective action across government, with health boards, local government
-     partners and the wider public sector, is fundamental to improving population
-     health and reducing health inequalities."),
-  p("A range of indicators are included in this Profile structured around the
-     evidence-based Marmot framework which looks at the social determinants of
-     health, the conditions in which people are born, grow, live, work and age
-     which can lead to health inequalities."),
+  nav_panel("Population Health dashboard",
+  h3("Population Health dashboard"),
+  p("The Population Health dashboard is a source of data and intelligence that supports the vision of Scotland’s Population Health Framework: to improve population health 
+    and address longstanding health inequalities. The dashboard includes data on both life expectancy and healthy life expectancy, as well as a range of other indicators to 
+    monitor population health outcomes."),
+  p("The dashboard is also designed to support the Collaboration for Health Equity in Scotland (CHES). Public Health Scotland (PHS) have joined with the Institute for Health
+    Equity (IHE) to strengthen and accelerate the action underway to improve Scotland’s health, increase wellbeing, and reduce health inequalities. IHE highlight that reducing 
+    health inequity requires action on the “Marmot Eight” principles as laid out in their work on ", 
+    tags$a("Marmot Places", href = "https://www.instituteofhealthequity.org/taking-action/marmot-places", target = "_blank")),
+  p("The indicators on the dashboard have been developed through consultation with stakeholders to provide a strategic focus on a shared set of outcomes. The indicator set remains
+    under development, and changes will be made in future as new data becomes available, and in response to feedback from users."),
   br()
   ),
-  nav_panel("Care & Wellbeing Portfolio (CWP)",
-  h3("Care & Wellbeing Portfolio (CWP)"),
-  p("The CWP is the principal strategic reform vehicle in the Scottish Government.
-     It brings oversight and coherence to the major health and care reform programmes designed to improve
-     population health, address health inequalities and improve health and care system sustainability."),
-  p("The underpinning framework of the Portfolio is the evidence-based Marmot
-     domains – \"policy objectives\" that create health and reduce inequalities.
-     This globally recognised framework was first set out in",
-    tags$a("Fair Society, Healthy Lives", href = "https://www.instituteofhealthequity.org/resources-reports/fair-society-healthy-lives-the-marmot-review", target = "_blank"),
-    "in 2010, updated in a",
-    tags$a("10 year on report.", href = "https://www.health.org.uk/publications/reports/the-marmot-review-10-years-on", target = "_blank"),
-    "The domains cover early years, education, work, living standards, healthy places, ill health prevention,
-     discrimination and racism, and environmental sustainability and equity."),
-  br()
+  
+  nav_panel("Population Health Framework",
+            h3("Population Health Framework"),
+            p("The Population Health dashboard is one source of data designed to monitor progress against the aims of the Scottish Government’s ten-year Population Health Framework (PHF)."),
+            p("As part of the PHF, a high level aim has been set:"),
+            p("By 2035 we will improve Scottish life expectancy whilst reducing the life expectancy gap between the most deprived 20% of local areas and the national average."),
+            p("The Scottish Government will provide updates on a regular basis offering an assessment of progress towards meeting this aim. This will include discussion of the 
+              headline life expectancy measure, along with other measures such as healthy life expectancy."),
+            p("The PHF sets out the Scottish Government’s commitment to build a clear and collaborative approach to improving the nation’s health, underpinned by evidence. It 
+              is deliberately long-term and focused on prevention, equity, and sustainability by addressing the root causes of poor health."),
+            p("The focus of the Framework is prevention. In health, prevention is about keeping people healthy and reducing the risk of poor health, illness, injury, 
+            and early death. A key lesson from the pandemic is that our resilience to future health threats is strengthened by creating and sustaining health and preventing 
+            avoidable poor health. This can be achieved by strengthening the building blocks referenced above, and creating environments that make it easier to live healthy lives."),
+            p("In particular, the Framework focuses on ‘primary prevention’ – action designed to stop problems from emerging in the first instance. This has been a priority in Scotland
+            since the Christie Commission on Public Services in 2011. The evidence on forecasted burden of disease, rising service demand, and financial sustainability is clear that 
+            prevention of poor health is required now more than ever."),
+            p("The Framework is structured around four key ‘primary prevention drivers’ of health and wellbeing which align with the ",
+              tags$a("King’s Fund population health pillars", href = "https://www.kingsfund.org.uk/insight-and-analysis/reports/vision-population-health", target = "_blank"),
+              "These population health pillars link to Sir Michael Marmot’s eight principles, which are the “building blocks” that form the structure of the dashboard. The indicators
+              included on the dashboard are designed to reflect progress against the aims and priorities of the PHF."),
+              br()
   ),
+  nav_panel("The Marmot Eight principles",
+            h3("The Marmot Eight principles"),
+            p("The indicators in the Population Health dashboard are structured around Sir Michael Marmot’s eight principles for health equity – these are policy objectives that create 
+              health and reduce inequalities. This globally recognised “Marmot Eight” evidence-based framework was first set out by the Institute of Health Equity in ",
+              tags$a("Fair Society, Healthy Lives", href = "https://www.instituteofhealthequity.org/resources-reports/fair-society-healthy-lives-the-marmot-review", target = "_blank"),
+              "in 2010, and updated in 2020 as part of the ",
+              tags$a("10 years on review report", href = "https://www.health.org.uk/publications/reports/the-marmot-review-10-years-on", target = "_blank"),  
+              ". The eight Marmot principles are:",
+              tags$ol(
+                tags$li(tags$b("Early years")," – Give every child the best start in life."), 
+                tags$li(tags$b("Education")," – Enable all children, young people and adults to maximise their capabilities and have control over their lives."), 
+                tags$li(tags$b("Work")," – Create fair employment and good work for all."),
+                tags$li(tags$b("Living standards")," – Ensure a healthy standard of living for all."),
+                tags$li(tags$b("Healthy places")," – Create and develop healthy and sustainable places and communities."),
+                tags$li(tags$b("Impact of ill-health prevention")," – Strengthen the role and impact of ill health prevention."),
+                tags$li(tags$b("Discrimination and racism")," – Tackle racism, discrimination and their outcomes."),
+                tags$li(tags$b("Environmental sustainability and health equity")," – Pursue environmental sustainability and health equity together.")
+                )),
+              br()
+            ),
+  nav_panel("Collaboration for Health Equity in Scotland",
+            h3("Collaboration for Health Equity in Scotland"),
+            p("Public Health Scotland (PHS) has joined with the University College London (UCL) Institute of Health Equity (IHE) for a two-year ",
+              tags$a("Collaboration for Health Equity in Scotland (CHES)", href = "https://publichealthscotland.scot/population-health/environmental-health-impacts/collaboration-for-health-equity-in-scotland/", target = "_blank"),
+              ". Working with Professor Sir Michael Marmot, the director of the Institute, this collaboration will strengthen and accelerate the action already underway to improve Scotland’s health, promote wellbeing, and address 
+              health inequalities. The partnership between PHS and IHE is to support public service reform and will cover two key areas: ",
+              tags$li("Work at a national level to provide new insights into the most effective ways to progress health equity in Scotland through Marmot’s eight principles."), 
+              tags$li("Work in partnership with local authorities and NHS boards across Aberdeen City, North Ayrshire, and South Lanarkshire to develop and implement strategies to enhance health equity.")), 
+              p("The ultimate goal is to enable people to live longer, healthier lives by addressing the root causes of health inequalities and preventing illness before it starts. By creating conditions in which communities 
+                can thrive, the initiative seeks to drive lasting, positive change."),
+              p("The Population Health dashboard provides a set of indicators structured around Marmot’s eight principles to inform progress towards this goal."),
+            br()),
+
   nav_panel("Other resources",
   h3("Other resources"),
-  p("The Care & Wellbeing Profile is one source of data and intelligence to support
-     the ambitions of CWP. A number of other sources of helpful information is also available:"),
-  tags$li("The ", tags$b("Improvement Service (IS)"), "is the 'go-to' organisation for local government improvement
-     in Scotland. It provides performance management and benchmarking products and services
-     to help councils assess and improve their own performance, and support decision-making
-     in councils and community planning partnerships. More information can be found at:",
-     tags$a("Improvement Service.", href = "https://www.improvementservice.org.uk/", target = "_blank")),
-  tags$li("The ", tags$b("National Performance Framework (NPF)"), "provides a measure of national
-     wellbeing and keeps track of how Scotland is performing. It aims to reduce
-     inequalities and gives equal importance to economic, environmental and social
-     progress. More information can be found at:",
-     tags$a("National Outcomes | National Performance Framework", href = "https://nationalperformance.gov.scot/national-outcomes", target = "_blank")),
-  br()
-  )
-)
+  p("The Population Health dashboard draws from existing sources of Population Health information to support policy-making at a national
+    and local level. The indicators aim to provide a strategic focus around policy priorities as set out in the Population Health Framework.
+    A wider range of indicators can also be accessed through the ScotPHO profiles tool and other existing sources of data. Other sources of data and evidence include:"),
+
+  tags$li(tags$a("Public Health Scotland (PHS).", href = "https://www.publichealthscotland.scot/", target = "_blank"),
+          "publishes a wide range of statistics related to public health outcomes, as well as the health and social care system."),
+
+  tags$li(tags$a("ScotPHO", href = "https://www.scotpho.org.uk/", target = "_blank"),
+          ", as well as the Online Profiles Tool, publish a wide range of reports and analysis on their website. These cover
+          a broad range of public health themes, including mental health, substance use, cardiovascular disease, children and young people’s health,
+          environmental health, and health inequalities, among others. Together, these resources support evidence-informed decision-making and help
+          monitor progress toward improving population health across Scotland."),
+
+  tags$li("The ",tags$a("PHS Health & wellbeing Metadata Catalogue ", href = "https://scotland.shinyapps.io/phs-metadata-catalogue/", target = "_blank"),
+          "tool provides metadata on easily accessible, publicly available health and wellbeing indicators for Scotland."),
+
+  tags$li("The ", tags$a("Improvement Service (IS)",href = "https://www.improvementservice.org.uk/", target = "_blank"),
+          " support local government improvement in Scotland providing performance management and benchmarking products and
+          services to help councils assess and improve their own performance, and support decision-making in councils and community planning partnerships. This includes the ",
+          tags$a("Improvement Service (IS)",href = "https://www.improvementservice.org.uk/benchmarking", target = "_blank"),
+          " and ",
+          tags$a("Community Planning Outcomes Profile",href = "https://www.improvementservice.org.uk/products-and-services/data-intelligence-and-benchmarking/community-planning-outcomes-profile", target = "_blank"))),
   
+  nav_panel("Additional links",
+            h3("Additional links"),
+            p("While the Population Health dashboard provides a strategic focus on a selection of indicators, a wealth of information is already available to provide Scottish 
+              insights relating to each of the eight Marmot principles. The following section highlights some key publications:"),
+            tags$ol(
+              tags$li(tags$b("Early years"),
+                      "PHS produce early ",
+                      tags$a("child development statistics",href = "https://publichealthscotland.scot/publications/early-child-development/early-child-development-statistics-scotland-2022-to-2023/", target = "_blank"),
+                      " annually. This provides data on the development of children aged 0-5 years, including the percentage of children presenting with a developmental concern.",
+                      "PHS also publish the ",
+                      tags$a("Health in the early years (HEYS) dashboard",href = "https://publichealthscotland.scot/publications/health-in-the-early-years-heys-dashboard/", target = "_blank"),
+                      ". This presents data on breastfeeding and early child development, including breakdowns for local areas.",
+                      "The Scottish Government regularly gather data on the funded early learning and childcare (ELC) entitlement through the ELC census. This collects information on ELC provisions
+                      from services that deliver this entitlement."),
+              tags$li(tags$b("Education"),
+                      "The Scottish Government publishes ",tags$a("school education statistics",href = "https://www.gov.scot/collections/school-education-statistics/", target = "_blank"),
+                      " annually. These statistics provide detail on the annual including pupil and teacher characteristics, as well has attainment and qualification 
+                      results. This is accompanied by various interactive dashboards that provide breakdowns for local areas."),
+              tags$li(tags$b("Work"),
+                      "The Scottish Government regularly publishes ",
+                      tags$a("labour market statistics",href = "https://www.gov.scot/collections/labour-market-statistics/", target = "_blank"),
+                      ". This includes Labour Force Survey data relating to employment, unemployment, and economic inactivity trends."),
+              tags$li(tags$b("Living standards"),
+                      "The Scottish Government regularly publish ",tags$a("poverty and income inequality",href = "https://www.gov.scot/collections/poverty-and-income-inequality-statistics/", target = "_blank")," statistics.",
+                      "The Scottish Government also regularly publish data on ",tags$a("primary income account and Gross National Income",href = "https://data.gov.scot/primary-income-account/", target = "_blank"),".",
+                      "The annual ",tags$a("Scottish Household Survey",href = "https://www.gov.scot/publications/scottish-household-survey-2022-key-findings/pages/5/", target = "_blank")," collects data on household finances.",
+                      "The ",tags$a("Scottish House Condition Survey",href = "https://www.gov.scot/collections/scottish-house-condition-survey/", target = "_blank")," collects data on the the physical condition of Scotland’s
+                      homes and the experiences of householders."),
+              tags$li(tags$b("Healthy places"),
+                      "The ",tags$a("Scottish Index of Multiple Deprivation",href = "https://simd.scot/#/simd2020/BTTTFTT/7.49077135520893/-4.0132/55.9875/", target = "_blank"),
+                      " measures the relative levels of deprivation in specific geographical areas across Scotland. This is based on information collected by the Scottish Government.",
+                      "The ",tags$a("Place Standard tool",href = "https://simd.scot/#/simd2020/BTTTFTT/7.49077135520893/-4.0132/55.9875/", target = "_blank"),
+                      " was developed by the Place Standard partners, which include the Scottish Government, Public Health Scotland, Architecture and Design Scotland,
+                      the Improvement Service and Glasgow City Council. The tool provides a framework for assessing places to inform local planning decisions. The",
+                      tags$a("Place and Wellbeing Outcomes",href = "https://www.improvementservice.org.uk/products-and-services/planning-and-place-based-approaches/planning-for-place-programme/place-and-wellbeing-outcomes", target = "_blank"),
+                      " were developed alongside the Place Standard tool, with relevant indicators identified to inform against the outcomes. ",
+                      tags$a("Understanding Scotland’s Places (USP)",href = "https://www.usp.scot/", target = "_blank"),
+                      "helps users to better understand the local areas in which people work and live. Deliberately designed to avoid a simplistic ranking of places as better or worse, USP focuses on the shared characteristics of towns."),
+              tags$li(tags$b("Impact of ill-health prevention"),
+                      "PHS regularly publish ",
+                      tags$a("disease prevalence data and statistics",href = "https://publichealthscotland.scot/publications/general-practice-disease-prevalence-data-visualisation/general-practice-disease-prevalence-visualisation-27-june-2023/", target = "_blank"),
+                      ". Vaccination is one of the most effective public health interventions to prevent disease and protect against severe disease. PHS’ ",
+                      tags$a("Vaccination Surveillance Dashboard",href = "https://scotland.shinyapps.io/phs-vaccination-surveillance/", target = "_blank"),
+                      "presents data to monitor trends in vaccination uptake, including equality breakdowns.",
+                      "National screening programmes have an important role to play in reducing health inequalities. PHS publish screening statistics for programmes including ",
+                      tags$a("bowel",href = "https://publichealthscotland.scot/publications/scottish-bowel-screening-programme-statistics/", target = "_blank"),",",
+                      tags$a("breast",href = "https://publichealthscotland.scot/publications/scottish-bowel-screening-programme-statistics/", target = "_blank"),"and ",
+                      tags$a("cervical",href = "https://publichealthscotland.scot/publications/scottish-bowel-screening-programme-statistics/", target = "_blank")," screening.",
+                      "The ", tags$a("Scottish Health Survey provides",href = "https://www.gov.scot/collections/scottish-health-survey/", target = "_blank"),
+                      " a detailed picture of the health of the Scottish population, and is designed to make a major contribution to the monitoring of health in Scotland."),
+              
+              tags$li(tags$b("Discrimination and racism"),
+                      "The Scottish Government’s ",
+                      tags$a("Equality Evidence Finder",href = "https://publichealthscotland.scot/publications/scottish-bowel-screening-programme-statistics/", target = "_blank"),
+                      " brings together the latest statistics and research for Scotland across different equality characteristics. This includes age, disability, ethnicity, 
+                      gender, religion, sexual orientation, socio-economic status, and transgender status."),
+              
+              tags$li(tags$b("Environmental sustainability and health equity"),
+                      "The Scottish Government regularly produces statistics on ",
+                      tags$a("greenhouse gas emissions",href = "https://www.gov.scot/publications/scottish-greenhouse-gas-statistics-2022/", target = "_blank"),
+                      " and ",
+                      tags$a("Scotland's carbon footprint",href = "https://www.gov.scot/publications/scotlands-carbon-footprint-1998-2018/", target = "_blank"),
+                      ". The ",
+                      tags$a("Scottish Climate Survey",href = "https://www.gov.scot/collections/scottish-climate-survey/", target = "_blank"),
+                      "is a nationally representative survey of Scottish adults’ awareness, understanding, and experiences of climate change-related issues. The Scottish Government also produces ",
+                      tags$a("energy statistics for Scotland",href = "https://www.gov.scot/collections/quarterly-energy-statistics-scotland/", target = "_blank"),
+                      ", which outlines trends in energy usage and energy targets each quarter. ",
+                      "The annual ",
+                      tags$a("climate change monitoring report",href = "https://www.gov.scot/publications/climate-change-monitoring-report-2024/", target = "_blank"),
+                      "is also produced by the Scottish Government, which measures progress against the Scottish Government’s ",
+                      tags$a("Scottish Climate Survey",href = "https://www.gov.scot/collections/scottish-climate-survey/", target = "_blank"),
+                      tags$a("climate change plan",href = "https://www.gov.scot/publications/securing-green-recovery-path-net-zero-update-climate-change-plan-20182032/", target = "_blank"),
+                      ".")
+            ) #close ordered list
+  ),#close nav panel
+  
+  nav_panel("Feedback",
+            h3("Feedback"),
+            p("The content of the Population Health dashboard will remain under review. We welcome feedback on all aspects of the dashboard including the indicator content and presentation. Please send any feedback to ",
+              tags$a("phs.scotpho@phs.scot", href = "mailto:phs.scotpho@phs.scot", target = "_blank")),
+            br())
+) #close pop health navset
+
 ###########################################.
 ### Health and Wellbeing ----
 
@@ -69,7 +196,7 @@ br()
 ),
 nav_panel("Target audience",
 h3("Target audience"),
-p("We expect that the following professional groups will find the information contained here of particular
+p("We expect that the following professional groups will find the infmation contained here of particular
 interest: public health and health improvement staff; health promotion officers; public health practitioners;
 planners and other health professionals within NHS Boards. It will also be of interest to those in government,
 local authorities, third sector and academia including planners and policy makers; community planning;

--- a/shiny_app/ui.R
+++ b/shiny_app/ui.R
@@ -194,14 +194,16 @@ page_navbar(
                                  
                                  # Display message at top of summary tab for specific profiles only
                                  # commenting out Jan 2025 but leaving script as placeholder as new text may come along 
-                                 # conditionalPanel(condition = "input.profile_choices == 'Care and Wellbeing'",
-                                 #                  br(),
-                                 #                  card(max_height = 150,
-                                 #                       card_header(bs_icon("info-circle-fill", size = "1.2em"),"Indicator set in development",class = "info-box-header"),
-                                 #                       p("The Care and Wellbeing indicator set will be further developed following user feedback. If you have any feedback please contact us at",
-                                 #                         tags$a("phs.scotpho@phs.scot.", href = "mailto:phs.scotpho@phs.scot?subject=Care%20and%20Wellbeing%20Indicator%20Feedback"))
-                                 #                       )
-                                 #                  ),
+                                 conditionalPanel(condition = "input.profile_choices == 'Population Health'",
+                                                  br(),
+                                                  card(max_height = 150,
+                                                       card_header(bs_icon("info-circle-fill", size = "1.2em"),"Indicator set in development",class = "info-box-header"),
+                                                       p("The Population Health dashboard has been developed to support the ambitions of Scotland’s Population Health Framework, and the Collaboration 
+                                                         for Health Equity in Scotland by providing access to the latest data on population health outcomes and inequalities. The indicators are structured 
+                                                         around the “Marmot Eight” principles as laid out in the Institute of Health Equity’s work on ",
+                                                         tags$a("Marmot Places", href = "https://www.instituteofhealthequity.org/taking-action/marmot-places", target = "_blank"),". ")
+                                                       )
+                                                  ),
                                  # only display this card when Mental Health profile selected
                                  conditionalPanel(condition = "input.profile_choices == 'Children & Young People Mental Health'",
                                                   br(),
@@ -235,7 +237,7 @@ page_navbar(
                        nav_panel(title = "About this profile", value = "about_profile_tab",
                                  br(),
                                  conditionalPanel("input.profile_choices == 'Health & Wellbeing'", about_hwb_text),
-                                 conditionalPanel("input.profile_choices == 'Care & Wellbeing Portfolio'", about_cwb_text),
+                                 conditionalPanel("input.profile_choices == 'Population Health'", about_cwb_text),
                                  conditionalPanel("input.profile_choices == 'Adult Mental Health'", about_men_text),
                                  conditionalPanel("input.profile_choices == 'Children & Young People Mental Health'", about_cmh_text),
                                  conditionalPanel("input.profile_choices == 'Alcohol'", about_alc_text),


### PR DESCRIPTION
Making some changes to text around the new name for the population health profile (new name for CWP)
I have not yet made changes to the short name for this profile - mostly because i'm sure if i rush it then i'll mess something up somewhere and there is a push to get the change made by next thursday.
I am a bit concerned that the massive amounts of extra text (with links) they want included in the 'about profiles' section slows down the loading of the app. Do you find the app takes longer than you'd expect to load or maybe its just a posit thing.
