### PR TITLE
ER - Update pop_groups_mod.R

### DIFF
--- a/shiny_app/modules/visualisations/pop_groups_mod.R
+++ b/shiny_app/modules/visualisations/pop_groups_mod.R
@@ -161,7 +161,7 @@ pop_groups_server <- function(id, dataset, geo_selections, selected_profile, roo
     observe({
       
       available_years <- dataset() |>
-        filter(indicator == selected_indicator() & areatype == geo_selections()$areatype & areaname == geo_selections()$areaname) |>
+        filter(indicator == selected_indicator() & areatype == geo_selections()$areatype & areaname == geo_selections()$areaname & split_name == input$split_filter) |>
         arrange(desc(year)) |>
         pull(unique(def_period))
       


### PR DESCRIPTION
Fixed the pop_rank_chart issue that occurred when the data for a split wasn't available for all def_periods in the data for that indicator.  Added additional filter for split_name, and this fixed it.