### PR TITLE
Ap cicerone fix

### DIFF
--- a/shiny_app/modules/visualisations/rank_charts_mod.R
+++ b/shiny_app/modules/visualisations/rank_charts_mod.R
@@ -75,7 +75,9 @@ rank_mod_ui <- function(id) {
       
       layout_column_wrap(
         # bar chart card ----------------------
-          navset_card_pill(
+          
+        div(id = ns("rank_chart_wrapper"),
+        navset_card_pill(
             id = ns("rank_navset_card_pill"),
             full_screen = TRUE,
             height = 600,
@@ -108,7 +110,7 @@ rank_mod_ui <- function(id) {
             footer = card_footer(class = "d-flex justify-content-left",
                         div(id = ns("rank_download_chart"), download_chart_mod_ui(ns("save_rank_chart"))),
                         div(id = ns("rank_download_data"), download_data_btns_ui(ns("rank_download"))))
-          ),
+          )),
        
         # map card -------------------
         
@@ -625,25 +627,26 @@ Not all profiles have available indicators for all geography types. The drugs pr
      guide_rank<- Cicerone$
        new()$
        step(
-         ns("rank_chart"), #chart tab
+         ns("rank_chart_wrapper"), #chart tab
          "Chart Tab",
          "These charts allow areas to be ranked against others of the same type.<br>
      You can also add a baseline comparator to assess whether each area in your chosen geography level is statistically significantly better or worse than your comparator.<br>
-     For example, you may want to assess whether each  is significantly higher or lower than a particular geographical area (for instance, the national average) or whether there are particular 
+     For example, you may want to assess whether each  is significantly higher or lower than a particular geographical area (for instance, the national average) or whether there are particular
      areas in your chosen geography level that are significantly higher or lower than they were at another point in time (e.g. a decade ago)",
-         position = "right",
-         tab_id = ns("rank_navset_card_pill"),
-         tab = ns("rank_chart_tab")
+         position = "right"
+         # ,
+         # tab_id = ns("rank_navset_card_pill"),
+         # tab = ns("rank_chart_tab")
        )$
        step(
          ns("rank_popover"), # popover icon
          "Adjust Chart Settings",
-         "Click here to add error bars the chart."
+         "Click here to add error bars to the chart."
        )$
        step(
          ns("rank_navset_card_pill"), #table tab
          "Other views",
-         "You can switch between viewing the chart for your selectd indicator.",
+         "You can switch between viewing the chart or data for your selected indicator using the buttons highlighted.",
          position = "right"
        )$
        step(

--- a/shiny_app/modules/visualisations/rank_charts_mod.R
+++ b/shiny_app/modules/visualisations/rank_charts_mod.R
@@ -634,9 +634,6 @@ Not all profiles have available indicators for all geography types. The drugs pr
      For example, you may want to assess whether each  is significantly higher or lower than a particular geographical area (for instance, the national average) or whether there are particular
      areas in your chosen geography level that are significantly higher or lower than they were at another point in time (e.g. a decade ago)",
          position = "right"
-         # ,
-         # tab_id = ns("rank_navset_card_pill"),
-         # tab = ns("rank_chart_tab")
        )$
        step(
          ns("rank_popover"), # popover icon

--- a/shiny_app/modules/visualisations/simd_mod.R
+++ b/shiny_app/modules/visualisations/simd_mod.R
@@ -51,8 +51,8 @@ simd_navpanel_ui <- function(id) {
                         
                         
                         #guided tour button
-                        actionLink(inputId = ns("deprivation_tour_button"),
-                                   label = "Take a guided tour of this page"),
+                        # actionLink(inputId = ns("deprivation_tour_button"),
+                        #            label = "Take a guided tour of this page"),
                         
                         # About SIMD button
                         actionLink(inputId = ns("simd_help"), 

--- a/shiny_app/modules/visualisations/trend_mod.R
+++ b/shiny_app/modules/visualisations/trend_mod.R
@@ -110,7 +110,7 @@ trend_mod_ui <- function(id) {
         
         # popover with extra controls for trend chart
         bslib::nav_item(
-          div(id = "trend_popover", bslib::popover(
+          div(id = ns("trend_popover"), bslib::popover(
             title = "Decide how to present data in the chart",
             chart_controls_icon(), 
             # rate/numerator toggle
@@ -583,15 +583,13 @@ trend_mod_server <- function(id, filtered_data, geo_selections, selected_profile
         padding = 8
       )$
       step(
-        ns("trend_chart"), # trend chart 
+        ns("trend_card_wrapper"), # trend chart
         title = "Chart Tab",
         description = "The trend chart is designed to explore how a single indicator has changed over time for one or more geographical areas. <br>
-        Use the mouse to hover over a data point and see detailed information on its value, time period and area.",
-        tab_id = ns("trend_navset_card_pill"), 
-        tab = ns("trend_chart_tab")
+        Use the mouse to hover over a data point and see detailed information on its value, time period and area."
       )$
       step(
-        "trend_popover", # popover icon
+        ns("trend_popover"), # popover icon
         "Adjust Chart Settings",
         "Click here to see chart settings. Confidence intervals (95%) can be added to the chart. They are shown as shaded areas and give an indication of the precision of a rate or percentage. The width of a confidence interval is related to sample size.
         The chart can also be switched from a measure (e.g. rate or percentage) to actual numbers (e.g. the number of births with a healthy birthweight)."


### PR DESCRIPTION
Hello, 

I've fixed the trend and rank tours. They weren't starting because of some sort of change to the name or structure of the navset_card_pills. I don't think the highlights are exactly the same as before but they should still make sense. I've commented out the deprivation tab action link also - that tour didn't work because it doesn't exist. I can look at creating this and a tour for the pop groups tab next :)

Thanks,
Abbie