### PR TITLE
ER - Allow default header in trend tooltip (i.e., the trend_axis label)

### DIFF
--- a/shiny_app/highcharter functions.R
+++ b/shiny_app/highcharter functions.R
@@ -69,7 +69,7 @@ create_multi_line_trend_chart <- function(data,
     hc_yAxis(title = "") |>
     hc_chart(marginRight = 15) |>
     hc_legend(verticalAlign = legend_position, align = "left") |>
-    hc_tooltip(headerFormat = "", crosshairs = TRUE, shared = TRUE)
+    hc_tooltip(crosshairs = TRUE, shared = TRUE)
   
   
   


### PR DESCRIPTION
There may have been a reason why we had opted to drop the trend_axis from the tooltips on trend charts, but I think it would be useful to include. It helps users to know which exact year(s) they're looking at, particularly when only the first and last years are labelled on the x-axis. 