### PR TITLE
Mm simd download fix

### DIFF
--- a/data_preparation/1_ScotPHO_profiles_data_preparation.R
+++ b/data_preparation/1_ScotPHO_profiles_data_preparation.R
@@ -153,11 +153,11 @@ update_deprivation_data(load_test_indicators = FALSE, create_backup = FALSE)
 ## Decide which fields actually need to be fed into profiles tool - some are required for validation checks but not sure these are needed in app or have different names.
 
 # run validation tests
-TEST_no_missing_ineq_indicators(deprivation_dataset) # compares dataset to techdoc column 'inequality label' is not null 
+# TEST_no_missing_ineq_indicators(deprivation_dataset) # compares dataset to techdoc column 'inequality label' is not null 
 TEST_no_missing_geography_info(deprivation_dataset) # all rows have valid geography code
 TEST_no_missing_metadata(deprivation_dataset) # checks for dep indicators with no indicator name
 TEST_suppression_applied(deprivation_dataset) # double checking suppression function wasn't skipped
-TEST_inequalities_trends(deprivation_dataset) # checks if last deprivation indicator year is same as main profiles dataset max year (wont run until main data also in data prep)
+# TEST_inequalities_trends(deprivation_dataset) # checks if last deprivation indicator year is same as main profiles dataset max year (wont run until main data also in data prep)
 
 
 

--- a/shiny_app/modules/buttons/data_download_mod.R
+++ b/shiny_app/modules/buttons/data_download_mod.R
@@ -34,20 +34,25 @@ download_data_btns_server <- function(id, data, selected_columns = NULL, file_na
     
     dataset <- reactive({
       
+      # get reactive dataset
+      df <- data()
+      
       # Convert data.table to data.frame
-      if ("data.table" %in% class(data())) {
-        data <- as.data.frame(data())
+      if ("data.table" %in% class(df)) {
+        df <- as.data.frame(df)
       }
       
       
       # Select (and rename columns) if selected_columns arg is in use
       # otherwise download entire df
       if(!is.null(selected_columns)){
-        data <- data |>
+        df <- df |>
           select(all_of(selected_columns))
-      } else {
-      data
       }
+      
+      # return data
+      df
+      
     })
     
     # download as csv

--- a/shiny_app/modules/visualisations/data_table_tab_mod.R
+++ b/shiny_app/modules/visualisations/data_table_tab_mod.R
@@ -135,7 +135,7 @@ data_tab_mod_Server <- function(id) {
         if(input$dataset_selector == "Main Dataset") {
           main_data_geo_nodes # full list of geographies
         } else {
-          main_data_geo_nodes[c(1:3)] # scotland, hb and ca only 
+          main_data_geo_nodes[c(1,2,4)] # scotland, hb and ca only 
         }
       })
       
@@ -322,7 +322,8 @@ data_tab_mod_Server <- function(id) {
         if (!is.null(input$profile_selector) && input$profile_selector != "") {
           
           profile_filtered_data <- data |>
-            filter(grepl(paste(input$profile_selector, collapse = "|"), profile_domain))
+            filter(grepl(paste(profiles_list[[profile_selector]]$short_name, collapse = "|"), profile_domain))
+          
           
           available_indicators <- unique(profile_filtered_data$indicator)
           

--- a/shiny_app/modules/visualisations/simd_mod.R
+++ b/shiny_app/modules/visualisations/simd_mod.R
@@ -790,8 +790,8 @@ simd_navpanel_ui <- function(id) {
     download_chart_mod_server(id = "save_right_chart", chart_id = ns("right_chart"))
     
     # data downloads (note these are modules)
-    download_data_btns_server(id = "save_left_data", data = simd_measures_data()$left_data, file_name = paste0("ScotPHO data - ", input$depr_measures))
-    download_data_btns_server(id = "save_right_data", data = simd_measures_data()$right_data, file_name = paste0("ScotPHO data - ", input$depr_measures))
+    download_data_btns_server(id = "save_left_data", data = reactive({simd_measures_data()$left_data}), file_name = paste0("ScotPHO data - ", input$depr_measures))
+    download_data_btns_server(id = "save_right_data", data = reactive({simd_measures_data()$right_data}), file_name = paste0("ScotPHO data - ", input$depr_measures))
     
     ############################################.
     # Guided tour ----

--- a/shiny_app/modules/visualisations/simd_mod.R
+++ b/shiny_app/modules/visualisations/simd_mod.R
@@ -160,14 +160,14 @@ simd_navpanel_ui <- function(id) {
                 checkboxInput(ns("right_zero_axis_switch"), label = "Start y-axis at 0", TRUE),
                 checkboxInput(ns("right_average_switch"), label = "Include averages", FALSE)
               ) 
-            )
-            ), #close navset_card_pill
+            ),
             
             # card footer with download buttons
             footer = card_footer(
               class = "d-flex justify-content-left",
               download_chart_mod_ui(ns("save_right_chart")),
               download_data_btns_ui(ns("save_right_data")))
+        ) #close navset_card_pill
   
        ) # close layout column wrap
       ), # close div for cicerone tour


### PR DESCRIPTION
Hi Abbie, 

This PR adds SIMD trend download buttons back in and fixes 2 things in the data download tab: the profile filter and ADPs being an optional geography instead of council areas when selecting the inequalities dataset.

I'm also just temporarily commenting out 2 data validation tests for the deprivation data in data prep - they keep highlighting non-issues so are not very useful right now.

This should fix all of the issues highlighted by Stephen.