### PR TITLE
Mm pr #3

### DIFF
--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -50,7 +50,7 @@ popgroup_dataset <- setDT(read_parquet("data/popgroup_dataset.parquet")) # datas
 geo_lookup <- setDT(readRDS("data/profiles_geo_lookup.rds")) # geography lookup
 main_data_geo_nodes <- readRDS("data/main_dataset_geography_nodes.rds") # geography nodes for data table tab
 techdoc <- read_parquet("data/techdoc.parquet") # technical document
-ltmhi_lookup <- data.table::fread("data/ltmhi_info.csv") # lookup for ltmhi indicators 
+#ltmhi_lookup <- data.table::fread("data/ltmhi_info.csv") # lookup for ltmhi indicators 
 
 
 # shapefiles (for map) 
@@ -228,18 +228,18 @@ profiles_list <- list(
     new = FALSE,
     active = TRUE
   )
-  ,
+#  ,
  # Scottish Health Inequalities (ie national level reporting on health inequalities)
  # to make visible uncomment below and also around line #310 in ui script which is linked to HI nav menu item
-  "Long-term Monitoring of Health Inequalities in Scotland" = list(
-      short_name = "SHI",
-      homepage_description = markdown("Under development - not yet available"),
-      domain_order = c("Headline indicators", "Morbidity and mortality", "Self-assesed/self-reported", "Service-use"),
-      subtabs = NULL,
-      nav_id = "shi_tab",
-      new = FALSE,
-      active = FALSE
-  )
+  # "Long-term Monitoring of Health Inequalities in Scotland" = list(
+  #     short_name = "SHI",
+  #     homepage_description = markdown("Under development - not yet available"),
+  #     domain_order = c("Headline indicators", "Morbidity and mortality", "Self-assesed/self-reported", "Service-use"),
+  #     subtabs = NULL,
+  #     nav_id = "shi_tab",
+  #     new = FALSE,
+  #     active = FALSE
+  # )
 
 )
 

--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -228,18 +228,18 @@ profiles_list <- list(
     new = FALSE,
     active = TRUE
   )
-  #,
-  # Scottish Health Inequalities (ie national level reporting on health inequalities)
-  # to make visible uncomment below and also around line #310 in ui script which is linked to HI nav menu item
-  # "Long-term Monitoring of Health Inequalities in Scotland" = list(
-  #     short_name = "SHI",
-  #     homepage_description = markdown("Under development - not yet available"),
-  #     domain_order = c("Headline indicators", "Morbidity and mortality", "Self-assesed/self-reported", "Service-use"),
-  #     subtabs = NULL,
-  #     nav_id = "shi_tab",
-  #     new = FALSE,
-  #     active = FALSE
-  # )
+  ,
+ # Scottish Health Inequalities (ie national level reporting on health inequalities)
+ # to make visible uncomment below and also around line #310 in ui script which is linked to HI nav menu item
+  "Long-term Monitoring of Health Inequalities in Scotland" = list(
+      short_name = "SHI",
+      homepage_description = markdown("Under development - not yet available"),
+      domain_order = c("Headline indicators", "Morbidity and mortality", "Self-assesed/self-reported", "Service-use"),
+      subtabs = NULL,
+      nav_id = "shi_tab",
+      new = FALSE,
+      active = FALSE
+  )
 
 )
 

--- a/shiny_app/modules/charts/bar_chart_mod.R
+++ b/shiny_app/modules/charts/bar_chart_mod.R
@@ -1,0 +1,270 @@
+#' Bar Chart Module
+#'
+#' A Shiny module that creates a bar chart using **highcharter** that is updated
+#' # using highcharter proxy functions
+#'
+#' @name bar_chart_mod
+
+
+
+#' Bar Chart Module UI
+#'
+#' Creates a UI container for a bar chart
+#'
+#' @param id Character string. 
+#'
+#' @return A `highchartOutput` element
+#'
+#' @examples
+#' # In UI:
+#' bar_chart_mod_UI("chart")
+#'
+
+
+bar_chart_mod_UI <- function(id) {
+  ns <- NS(id)
+  tagList(
+    highchartOutput(ns("bar_chart"))
+  )
+}
+
+
+
+#' Bar Chart Module Server
+#'
+#' Server logic for rendering and updating a highcharter bar chart.
+#'
+#' The chart is rendered once on initial load. All subsequent updates 
+#' (changes in the dataset or chart control options) are done using
+#' **highcharter proxy functions**, without re-rendering the entire chart.
+#'
+#' @param id Character string. The module's namespace ID (should match the UI function).
+#'
+#' @param r_data A **reactive** dataset to be plotted.
+#'   The dataset must contain the columns specified in `x_col`, `y_col`,
+#'   and optionally `lowci_col` / `upci_col`.
+#'
+#' @param x_col Character string. Name of the column used for the x-axis. 
+#' @param y_col Character string. Name of the column used for the y-axis. Must be one of: `"measure"`, `"rii_int"`, `"sii"`, `"par"`.
+#' @param lowci_col,upci_col Character strings or `NULL`.Column names for the lower/upper CIs. Required if CIs enabled in `r_chart_controls`.
+#'@param avg_col Character string or `NULL`. Column name for the average line. Required if average enabled in`r_chart_controls`.
+#'
+#'
+#' @param r_chart_controls A **reactiveValues** object containing chart control options, e.g.:
+#'   - `ci_switch` (logical): add/remove confidence intervals
+#'   - `zero_yaxis_switch` (logical): force y-axis to start at zero
+#'   - `avg_switch` (logical): add/remove average line
+#'
+#' @return None. This server function is called for its side-effects
+#'   (it renders and updates a highchart in the UI).
+#'
+#' @examples
+#' # In server:
+#' bar_chart_mod_Server(
+#'   id = "bar_chart",
+#'   r_data = simd_data,
+#'   x_col = "quintiles"
+#'   y_col = "measure",
+#'   r_chart_controls = sii_controls
+#' )
+
+
+bar_chart_mod_Server <- function(id,
+                             r_data,
+                             r_chart_controls,
+                             x_col,
+                             y_col,
+                             avg_col = NULL,
+                             upci_col = NULL,
+                             lowci_col = NULL) {
+  moduleServer(
+    id,
+    function(input, output, session) {
+      
+      ns <- session$ns
+      
+      
+      
+      
+      # colour palette
+      simd_colours <- c("#0078D4", "#DFDDE3", "#DFDDE3", "#DFDDE3", "#9B4393")
+      
+      # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      # render chart once on initial load -----
+      # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      
+      # Chart is created based on default selections when the app loads
+      # wrapping in isolate() ensures this code doesn't run again -
+      # all subsequent updates are done using highcharter proxy functions
+      # note: each series must have it's own id for this to work!
+      output$bar_chart <- renderHighchart({
+        
+        isolate({
+          
+          # data to plot
+          df <- r_data()
+          
+          # create bar chart 
+          hc <- highchart() |>
+            hc_add_series(
+              id = "bar_series", 
+              type = "column",
+              data = purrr::map2(df[[y_col]], simd_colours, ~ list(y = .x, color = .y))
+            ) |>
+            hc_xAxis(categories = unique(df[[x_col]])) |>
+            hc_add_theme(theme) |>
+            hc_legend(enabled = FALSE)
+          
+          # add confidence intervals if switched on by default
+          if("ci_switch" %in% names(r_chart_controls)){
+            if(isTRUE(r_chart_controls$ci_switch)){
+              
+              hc <- hc |> 
+                hc_add_series(
+                  id = "ci_series",
+                  type = "errorbar",
+                  data = purrr::map2(df[[lowci_col]], df[[upci_col]], ~ c(.x, .y)),
+                  zIndex = 10, stemColor = "#000000", whiskerColor = "#000000"
+                )
+              
+            }
+          }
+          
+          # start y-axis at 0 if switched on by default
+          if("zero_yaxis_switch" %in% names(r_chart_controls)){
+            if(isTRUE(r_chart_controls$zero_yaxis_switch)){
+              hc_yAxis(hc, min = 0)
+            }
+          }
+          
+          # add average line if switched on by default
+          if("avg_switch" %in% names(r_chart_controls)){
+            if(isTRUE(r_chart_controls$avg_switch)){
+              hc <- hc |>
+                hc_add_series(
+                  id = "avg_series",
+                  type = "line",
+                  data = r_data()[[avg_col]]
+                )
+            }
+          }
+          
+          # remove animation
+          hc |>
+            hc_plotOptions(series = list(animation = FALSE)) |>
+            hc_chart(animation = FALSE)
+          
+          
+        })
+      })
+      
+      
+      
+      # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      # update chart when r_data is updated ----
+      # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      
+      # whenever the reactive dataset is updated, update the chart.
+      # Using proxy functions allows you to manipulate the chart 
+      # without having to completely re-render it
+      
+
+      observeEvent(r_data(), {
+        
+        # get the already rendered bar chart 
+        hc <- highchartProxy(ns("bar_chart"))
+        
+        # data to plot 
+        df <- r_data()
+        
+        # update the x-axis
+        hcpxy_update(hc, xAxis = list(categories = unique(df[[x_col]])), redraw = FALSE)
+        
+        # update the bars 
+        hcpxy_update_series(hc, id = "bar_series", data = df[[y_col]], redraw = FALSE)
+        
+        # update the average line (if avg switch is on)
+        if("avg_switch" %in% names(r_chart_controls)){
+          if(isTRUE(r_chart_controls$avg_switch)){
+            hcpxy_update_series(hc, id = "avg_series", data = df[[avg_col]], redraw = FALSE)
+          }
+        }
+        
+        # update ci_switch series (if ci_switch is on)
+        if("ci_switch" %in% names(r_chart_controls)){
+          if(isTRUE(r_chart_controls$ci_switch)){
+            
+            hcpxy_update_series(
+              hc, 
+              id = "ci_series",
+              data = purrr::map2(df[[lowci_col]], df[[upci_col]], ~ c(.x, .y)), redraw = FALSE)
+            
+          }
+        }
+        
+        # redraw once all updates done
+        hcpxy_redraw(hc)
+        
+        
+      }, ignoreInit = TRUE)
+      
+      
+      # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      # Adding/removes series in response to chart control switches ----
+      # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      
+      # adding/removing ci series
+      observeEvent(r_chart_controls$ci_switch, {
+        
+        # get already rendered bar chart 
+        hc <- highchartProxy(ns("bar_chart"))
+        
+        # add/remove series
+        if(isTRUE(r_chart_controls$ci_switch)){
+          hcpxy_add_series(
+            hc,
+            id = "ci_series",
+            type = "errorbar",
+            data = purrr::map2(r_data()[[lowci_col]], r_data()[[upci_col]], ~ c(.x, .y))
+          )
+        } else {
+          hcpxy_remove_series(hc, id = "ci_series")
+        }
+        
+      }, ignoreInit = TRUE)
+      
+      
+      # adding/removing average line
+      observeEvent(r_chart_controls$avg_switch, {
+        
+        # get already rendered bar chart
+        hc <- highchartProxy(ns("bar_chart"))
+        
+        
+        # add/remove series
+        if(isTRUE(r_chart_controls$avg_switch)){
+          hcpxy_add_series(
+            hc,
+            data = r_data()[[avg_col]],
+            id = "avg_series",
+            type = "line"
+          )
+        } else {
+          hcpxy_remove_series(hc, id = "avg_series")
+        }
+        
+      }, ignoreInit = TRUE)
+      
+      # starting y-axis at 0
+      observeEvent(input$r_chart_controls$zero_yaxis_switch, {
+        highchartProxy(ns("bar_chart")) |>
+          hcpxy_update(
+            yAxis = list(min = if (isTRUE(r_chart_controls$zero_yaxis_switch)) 0 else NULL)
+          )
+      }, ignoreInit = TRUE)
+      
+    }
+  )
+}
+
+

--- a/shiny_app/modules/charts/multi_trend_chart.R
+++ b/shiny_app/modules/charts/multi_trend_chart.R
@@ -1,0 +1,425 @@
+#' Multi Trend Chart Module
+#'
+#' A Shiny module that creates a trend chart using **highcharter** that is updated
+#' # using highcharter proxy functions
+#'
+#' @name multi_trend_chart_mod
+
+
+
+#' Multi Trend Chart Module UI
+#'
+#' Creates a UI container for a multi line trend chart
+#'
+#' @param id Character string. 
+#'
+#' @return A `highchartOutput` element
+#'
+#' @examples
+#' # In UI:
+#' multi_trend_chart_mod_UI("chart")
+#'
+
+multi_trend_chart_mod_UI <- function(id) {
+  ns <- NS(id)
+  tagList(
+    highchartOutput(ns("multi_trend_chart"))
+  )
+}
+
+#' Multi rend Chart Module Server
+#'
+#' Server logic for rendering and updating a highcharter trend chart.
+#'
+#' The chart is rendered once on initial load. All subsequent updates 
+#' (changes in the dataset or chart control options) are done using
+#' **highcharter proxy functions**, without re-rendering the entire chart.
+#'
+#' @param id Character string. The module's namespace ID (should match the UI function).
+#'
+#' @param r_data A **reactive** dataset to be plotted.
+#'   The dataset must contain the columns specified in `x_col`, `y_col`,
+#'   and optionally `lowci_col` / `upci_col`.
+#'
+#' @param x_col Character string. Name of the column used for the x-axis. 
+#' @param y_col Character string. Name of the column used for the y-axis.
+#' @param lowci_col,upci_col Character strings or `NULL`.Column names for the lower/upper CIs. Required if CIs enabled in `r_chart_controls`.
+#' @param avg_col Character string or `NULL`. Column name for the average line. Required if average enabled in`r_chart_controls`.
+#'
+#'
+#' @param r_chart_controls A **reactiveValues** object containing chart control options, e.g.:
+#'   - `ci_switch` (logical): add/remove confidence intervals
+#'   - `zero_yaxis_switch` (logical): force y-axis to start at zero
+#'   - `avg_switch` (logical): add/remove average line
+#'
+#' @return None. This server function is called for its side-effects
+#'   (it renders and updates a highchart in the UI).
+#'
+#' @examples
+#' # In server:
+#' multi_trend_chart_mod_Server(
+#'   id = "simd_trend_chart",
+#'   r_data = simd_data,
+#'   x_col = "trend_axis"
+#'   y_col = "measure",
+#'   group_col = "quintile",
+#'   r_chart_controls = simd_controls
+#' )
+#' 
+#' 
+#' 
+
+
+
+
+multi_trend_chart_mod_Server <- function(id,
+                                   r_data,
+                                   x_col = "trend_axis",
+                                   y_col = "measure",
+                                   group_col,
+                                   r_chart_controls,
+                                   avg_col = NULL,
+                                   lowci_col = NULL,
+                                   upci_col = NULL) {
+  moduleServer(
+    id,
+    function(input, output, session) {
+      
+      ns <- session$ns
+      
+      
+      # reactive value to store id for each line
+      curr_series_ids <- reactiveVal(character(0))
+      
+
+      # chart colours (to be expanded for non SIMD charts)
+      palette <- list(
+        "1 - most deprived" =  "#9B4393",
+        "5 - least deprived" =  "#0078D4",
+        "10 - least deprived" = "#0078D4",
+        "2" = "#DFDDE3",
+        "3" = "#DFDDE3",
+        "4" = "#DFDDE3",
+        "5" = "#DFDDE3",
+        "6" = "#DFDDE3",
+        "7" = "#DFDDE3",
+        "8" = "#DFDDE3",
+        "9" = "#DFDDE3"
+      )
+      
+      # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      # render chart once on initial load -----
+      # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      
+      # Chart is created based on default selections when the app loads
+      # wrapping in isolate() ensures this code doesn't run again -
+      # all subsequent updates are done using highcharter proxy functions
+      output$multi_trend_chart <- renderHighchart({
+        
+        isolate({
+          
+          df <- r_data() # data to plot
+          groups <- unique(df[[group_col]]) # lines to plot
+          
+          
+          # update reactive val with the names of groups being plotted
+          # on initial load 
+          curr_series_ids(groups)
+          
+          # create line series data 
+          line_series_data <- map(groups, function(group){
+            list(
+              id = group,
+              name = group,
+              type = "line",
+              color = palette[[group]],
+              # list_parse2 is a highcarter function that formats data into a list
+              data = list_parse2(df[df[[group_col]] == group, c(x_col, y_col)])
+            )
+          })
+
+          # create line chart
+          hc <- highchart() |>
+            hc_add_series_list(line_series_data) |> # pass line series data to chart
+            hc_xAxis(
+              type = "category",
+              # only plot first and last year as labels on x-axis
+              labels = list(
+                rotation = 0, 
+                style = list(
+                  textOverflow = 'none'
+                ),
+                formatter = JS("function() {
+               if (this.isFirst || this.isLast) {
+                 return this.value;
+               } else {
+                 return '';
+               }
+             }")
+              )) |>
+            hc_chart(marginRight = 15) |>
+            hc_legend(enabled = TRUE) |>
+            hc_add_theme(theme) # theme is from global script
+          
+          
+          # add confidence intervals if switched on by default
+          if("ci_switch" %in% names(r_chart_controls)){
+            if(isTRUE(r_chart_controls$ci_switch)){
+
+              # create ci series data 
+              ci_series_data <- map(groups, function(group){
+                list(
+                  id = paste0("ci-", group),
+                  name = paste0("ci-", group),
+                  type = "arearange",
+                  color = palette[[group]],
+                  showInLegend = FALSE,
+                  fillOpacity = 0.2,
+                  enableMouseTracking = FALSE, 
+                  zIndex = -1, 
+                  data = list_parse2(df[df[[group_col]] == group, c(x_col, upci_col, lowci_col)])
+                )
+              })
+              
+              # pass ci series data to the chart 
+              hc <- hc |>
+                hc_add_series_list(ci_series_data)
+              
+            }
+          }
+          
+          # start y-axis at 0 if switched on by default
+          if("zero_yaxis_switch" %in% names(r_chart_controls)){
+            if(isTRUE(r_chart_controls$zero_yaxis_switch)){
+              hc <- hc|>
+                hc_yAxis(min = 0)
+            }
+          }
+          
+          # add average line if switched on by default
+          if("zero_yaxis_switch" %in% names(r_chart_controls)){
+            if(isTRUE(r_chart_controls$avg_switch)){
+              hc <- hc |>
+                hc_add_series(
+                  type = "line",
+                  showInLegend = TRUE,
+                  id = "avg",
+                  name = "Average",
+                  color = "red",
+                  data = list_parse2(df[, c(x_col, avg_col)])
+                )
+            }
+          }
+          
+          
+          # remove animation
+          hc <- hc |>
+            hc_plotOptions(series = list(animation = FALSE)) |>
+            hc_chart(animation = FALSE)
+          
+          hc
+          
+          
+        })
+      })
+      
+      
+      
+      # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      # Update chart using proxy functions -------------
+      # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      # highcharter proxy functions let you update an already built chart without re-rendering
+      # from scratch - faster way update a chart in response to user input:
+      # https://jkunst.com/highcharter/reference/index.html#shiny-and-proxy-functions
+
+
+
+      ## a. Updates in response to r_data changing -----
+      # i.e. updating the data that is plotted
+
+      # whenever the reactive dataset is updated, update the chart:
+      observeEvent(r_data(), {
+
+          # data to be plotted
+          df <- r_data()
+
+          old_group_ids <- isolate(curr_series_ids()) # old lines that were plotted
+          new_group_ids <- unique(df[[group_col]]) # new lines to be plotted
+
+
+          # get chart that's already rendered
+          hc <- highchartProxy(ns("multi_trend_chart"))
+          
+          
+          # update xaxis
+          hc <- hcpxy_update(hc, xAxis = list(categories = unique(df[[x_col]])), redraw = FALSE)
+
+
+          # check what's to be added, removed or updated
+          remove <- setdiff(old_group_ids, new_group_ids)
+          add <- setdiff(new_group_ids, old_group_ids)
+          update <- intersect(old_group_ids, new_group_ids)
+
+          
+          # remove lines (if applicable)
+          if (length(remove) > 0) {
+            hc <- hcpxy_remove_series(hc, id = remove)
+          }
+          
+          
+          # add lines (if applicable)
+          if(length(add) > 0){
+            
+            walk(add, ~ {
+              hc <- hcpxy_add_series(
+               hc,
+               id = .x,
+               name = .x,
+               type = "line",
+               color = palette[[.x]],
+               data = list_parse2(df[df[[group_col]] == .x, c(x_col, y_col)]),
+               redraw = FALSE
+              )
+            })
+            
+            # add matching CI series (if applicable)
+            if (isTRUE(r_chart_controls$zero_yaxis_switch)){
+              walk(add, ~ {
+                hc <- hcpxy_add_series(
+                  hc,
+                  id = paste0("ci-",.x),
+                  name = paste0("ci-",.x),
+                  type = "arearange",
+                  color = palette[[.x]],
+                  showInLegend = FALSE,
+                  fillOpacity = 0.2,
+                  enableMouseTracking = FALSE, 
+                  zIndex = -1, 
+                  data = list_parse2(df[df[[group_col]] == .x, c(x_col, upci_col, lowci_col)]),
+                  redraw = FALSE
+                )
+              }) 
+            }
+          }
+          
+          
+          # update lines (if applicable)
+          if(length(update) > 0){
+            walk(update, ~ {
+              hc <- hcpxy_update_series(
+                hc, 
+                id = .x, 
+                data = list_parse2(df[df[[group_col]] == .x, c(x_col, y_col)]), 
+                redraw = FALSE
+                )
+            })
+          }
+            
+            # update matching CI series (if applicable)
+            if (isTRUE(r_chart_controls$zero_yaxis_switch)){
+              walk(update, ~ {
+                hc <- hcpxy_update_series(
+                  hc, 
+                  id = paste0("ci-", .x), 
+                  data = list_parse2(df[df[[group_col]] == .x, c(x_col, upci_col, lowci_col)]), 
+                  redraw = FALSE
+                )
+              })
+            }
+              
+              
+              # update average line (if applicable)
+                if(isTRUE(r_chart_controls$avg_switch)){
+                  hc <- hc |>
+                    hcpxy_update_series(
+                      id = "avg",
+                      data = list_parse2(df[, c(x_col, avg_col)])
+                    )
+                }
+
+
+          # update reactive val with series ids of each line plotted
+          curr_series_ids(new_group_ids)
+
+
+
+        # redraw once all chart updates done
+        hc |>
+          hcpxy_redraw()
+
+
+      }, ignoreInit = TRUE)
+
+
+      
+      ## b. Updates in response to chart controls changing -----
+      # i.e. adding/removing bits from the chart
+
+      # starting y-axis at 0
+      observeEvent(r_chart_controls$zero_yaxis_switch, {
+        highchartProxy(ns("multi_trend_chart")) |>
+          hcpxy_update(
+            yAxis = list(min = if (isTRUE(r_chart_controls$zero_yaxis_switch)) 0 else NULL)
+          )
+      }, ignoreInit = TRUE)
+      
+      
+      # adding/removing CI series
+      observeEvent(r_chart_controls$ci_switch, {
+        
+        hc <- highchartProxy(ns("multi_trend_chart"))
+        groups <- curr_series_ids()
+        
+        if (isTRUE(r_chart_controls$ci_switch)){
+           walk(groups, ~ {
+            hc <- hcpxy_add_series(
+              hc,
+              id = paste0("ci-",.x),
+              name = paste0("ci-",.x),
+              type = "arearange",
+              color = palette[[.x]],
+              linkedTo = .x,
+              showInLegend = FALSE,
+              fillOpacity = 0.2,
+              enableMouseTracking = FALSE, 
+              zIndex = -1, 
+              showInLegend = FALSE,
+              data = list_parse2(r_data()[r_data()[[group_col]] == .x, c(x_col, upci_col, lowci_col)]),
+              redraw = FALSE
+            )
+          })
+        } else {
+          hc <- hcpxy_remove_series(hc, id = paste0("ci-", groups))
+        }
+           
+          hc
+          
+      }, ignoreInit = TRUE)
+      
+      
+      # adding/removing average line
+      observeEvent(r_chart_controls$avg_switch, {
+
+          if(isTRUE(r_chart_controls$avg_switch)){
+            highchartProxy(ns("multi_trend_chart")) |>
+              hcpxy_add_series(
+                type = "line",
+                showInLegend = TRUE,
+                id = "avg",
+                name = "Average",
+                color = "red",
+                data = list_parse2(df[, c(x_col, avg_col)])
+              )
+          } else {
+            highchartProxy(ns("multi_trend_chart")) |>
+              hcpxy_remove_series(id = "avg")
+          }
+        
+        
+      }, ignoreInit = TRUE)
+
+
+    }
+  )
+}

--- a/shiny_app/modules/charts/stacked_bar_chart_mod.R
+++ b/shiny_app/modules/charts/stacked_bar_chart_mod.R
@@ -97,11 +97,25 @@ stacked_bar_chart_mod_Server <- function(id,
       curr_series_ids(ids)
       
       
-      # create chart
-      hc <- hchart(
-        df, 
-        type = 'column', 
-        hcaes(y = .data[[y_col]], group = .data[[group_col]], x = .data[[x_col]])) |>
+      # create series data
+      # For each group do the following:
+      series_data <- map(ids, ~ {
+        
+        # a. get data for that particular group:
+        bar_data <- df[df[[group_col]] == .x, ]
+        
+        # b. turn group data into list
+        list(
+          id = .x,
+          name = .x,
+          type = "column",
+          data = list_parse2(bar_data[, c(x_col, y_col)])
+        )
+      })
+      
+      # create highchart
+      hc <- highchart() |>
+        hc_add_series_list(series_data) |>
         hc_plotOptions(series = list(stacking = "normal")) |>
         hc_xAxis(categories = unique(df[[x_col]])) |>
         hc_colors(c(phs_colors("phs-blue"), phs_colors("phs-purple"))) |>

--- a/shiny_app/modules/charts/stacked_bar_chart_mod.R
+++ b/shiny_app/modules/charts/stacked_bar_chart_mod.R
@@ -1,0 +1,183 @@
+#' Stacked bar Chart Module
+#'
+#' A Shiny module that creates a stacked bar chart using **highcharter** that is updated
+#' # using highcharter proxy functions
+#'
+#' @name stacked_bar_chart_mod
+
+
+
+#' Stacked Bar chart Module UI
+#'
+#' Creates a UI container for a stacked bar chart
+#'
+#' @param id Character string. 
+#'
+#' @return A `highchartOutput` element
+#'
+#' @examples
+#' # In UI:
+#' stacked_bar_chart_mod_UI("chart")
+#'
+
+
+stacked_bar_chart_mod_UI <- function(id) {
+  ns <- NS(id)
+  tagList(
+      highchartOutput(ns("stacked_bar")) 
+  )
+
+}
+
+
+
+#' Stacked bar Chart Module Server
+#'
+#' Server logic for rendering and updating a highcharter stacked bar chart.
+#'
+#' The chart is rendered once on initial load. All subsequent updates 
+#' (changes in the dataset or chart control options) are done using
+#' **highcharter proxy functions**, without re-rendering the entire chart.
+#'
+#' @param id Character string. The module's namespace ID (should match the UI function).
+#'
+#' @param r_data A **reactive** dataset to be plotted.
+#'   The dataset must contain the columns specified in `x_col`, `y_col`
+#'
+#' @param x_col Character string. Name of the column used for the x-axis. 
+#' @param y_col Character string. Name of the column used for the y-axis. Must be one of: `"measure"`, `"rii_int"`, `"sii"`, `"par"`.
+#' @param group_col Character string. Name of the categories for the bar stacks. 
+#'
+#' @return None. This server function is called for its side-effects
+#'   (it renders and updates a highchart in the UI).
+#'
+#' @examples
+#' # In server:
+#' stacked_bar_chart_mod_Server(
+#'   id = "chart",
+#'   r_data = simd_data,
+#'   x_col = "quintile"
+#'   group_col = "measure_type",
+#'   y_col = "value"
+#' )
+
+stacked_bar_chart_mod_Server <- function(id,
+                                         r_data,
+                                         x_col,
+                                         y_col,
+                                         group_col) {
+  
+  moduleServer(
+    id,
+    function(input, output, session) {
+      
+      ns <- session$ns
+      
+      
+      # reactive value to store id for each stack
+      curr_series_ids <- reactiveVal(character(0))
+      
+      
+      # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      # render chart once on initial load -----
+      # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      
+      # Chart is created based on default selections when the app loads
+      # wrapping in isolate() ensures this code doesn't run again -
+      # all subsequent updates are done using highcharter proxy functions
+      # note: each series must have it's own id for this to work!
+      output$stacked_bar <- renderHighchart({
+        isolate({
+      
+      df  <- r_data() # data to plot 
+      ids <- unique(df[[group_col]]) # stacks to plot 
+      
+      # update reactive value with id of stacks 
+      # plotted on initial load
+      curr_series_ids(ids)
+      
+      
+      # create chart
+      hc <- hchart(
+        df, 
+        type = 'column', 
+        hcaes(y = .data[[y_col]], group = .data[[group_col]], x = .data[[x_col]])) |>
+        hc_plotOptions(series = list(stacking = "normal")) |>
+        hc_xAxis(categories = unique(df[[x_col]])) |>
+        hc_colors(c(phs_colors("phs-blue"), phs_colors("phs-purple"))) |>
+        hc_add_theme(theme)
+      
+      # remove animation
+        hc |>
+        hc_plotOptions(series = list(animation = FALSE)) |>
+        hc_chart(animation = FALSE)
+        
+    })
+    
+  })
+  
+
+
+
+
+      # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      # update chart when r_data is updated ----
+      # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      
+      # whenever the reactive dataset is updated, update the chart.
+      # Using proxy functions allows you to manipulate the chart 
+      # without having to completely re-render it
+      
+  observeEvent(r_data(), {
+    
+    # data to be plotted
+    df <- r_data()
+    
+    old_group_ids <- isolate(curr_series_ids()) # old stacks that were plotted
+    new_group_ids <- unique(df[[group_col]]) # new stacks to be plotted
+    
+    
+    # get chart that's already rendered
+    hc <- highchartProxy(ns("stacked_bar"))
+    
+    # check if there are any stacks to be removed
+    # and if there are, remove them.
+    groups_to_remove <- setdiff(old_group_ids, new_group_ids)
+    
+    if (length(groups_to_remove) > 0) {
+      hcpxy_remove_series(hc, id = groups_to_remove)
+    }
+    
+    
+    # check if there are any stacks to be either updated
+    # or added and if there are, update/add them.
+    walk(new_group_ids, ~ {
+      
+      # get data for particular group:
+      bar_data <- df[df[[group_col]] == .x, ]
+      
+      # turn group data into list
+      bar_data <- list_parse2(bar_data[, c(x_col, y_col)])
+      
+      # if series id existed previously, update, otherwise add as new series
+      if (.x %in% old_group_ids) {
+        hcpxy_update_series(hc, id = .x, name = .x, data = bar_data, redraw = FALSE)
+      } else {
+        hcpxy_add_series(hc, id = .x, name = .x, data = bar_data, type = "column", redraw = FALSE)
+      }
+    })
+    
+    # update reactive val with series ids of new plotted stacks
+    curr_series_ids(new_group_ids)
+
+    
+    # redraw chart once all updates done
+    hc |> hcpxy_redraw()
+    
+  }, ignoreInit = TRUE)
+
+  
+    }
+  )
+}
+

--- a/shiny_app/modules/charts/trend_chart_mod.R
+++ b/shiny_app/modules/charts/trend_chart_mod.R
@@ -1,0 +1,266 @@
+#' Trend Chart Module
+#'
+#' A Shiny module that creates a trend chart using **highcharter** that is updated
+#' # using highcharter proxy functions
+#'
+#' @name trend_chart_mod
+
+
+
+#' Trend Chart Module UI
+#'
+#' Creates a UI container for a bar chart
+#'
+#' @param id Character string. 
+#'
+#' @return A `highchartOutput` element
+#'
+#' @examples
+#' # In UI:
+#' trend_chart_mod_UI("chart")
+#'
+
+trend_chart_mod_UI <- function(id) {
+  ns <- NS(id)
+  tagList(
+    highchartOutput(ns("trend_chart"))
+  )
+}
+
+#' Trend Chart Module Server
+#'
+#' Server logic for rendering and updating a highcharter trend chart.
+#'
+#' The chart is rendered once on initial load. All subsequent updates 
+#' (changes in the dataset or chart control options) are done using
+#' **highcharter proxy functions**, without re-rendering the entire chart.
+#'
+#' @param id Character string. The module's namespace ID (should match the UI function).
+#'
+#' @param r_data A **reactive** dataset to be plotted.
+#'   The dataset must contain the columns specified in `x_col`, `y_col`,
+#'   and optionally `lowci_col` / `upci_col`.
+#'
+#' @param x_col Character string. Name of the column used for the x-axis. 
+#' @param y_col Character string. Name of the column used for the y-axis. Must be one of: `"measure"`, `"rii_int"`, `"sii"`, `"par"`.
+#' @param lowci_col,upci_col Character strings or `NULL`.Column names for the lower/upper CIs. Required if CIs enabled in `r_chart_controls`.
+#'@param avg_col Character string or `NULL`. Column name for the average line. Required if average enabled in`r_chart_controls`.
+#'
+#'
+#' @param r_chart_controls A **reactiveValues** object containing chart control options, e.g.:
+#'   - `ci_switch` (logical): add/remove confidence intervals
+#'   - `zero_yaxis_switch` (logical): force y-axis to start at zero
+#'   - `avg_switch` (logical): add/remove average line
+#'
+#' @return None. This server function is called for its side-effects
+#'   (it renders and updates a highchart in the UI).
+#'
+#' @examples
+#' # In server:
+#' trend_chart_mod_Server(
+#'   id = "bar_chart",
+#'   r_data = simd_data,
+#'   x_col = "quintiles"
+#'   y_col = "measure",
+#'   r_chart_controls = sii_controls
+#' )
+
+
+
+trend_chart_mod_Server <- function(id,
+                               r_data,
+                               x_col = "trend_axis",
+                               y_col = c("measure", "rii_int", "sii", "par"),
+                               r_chart_controls,
+                               lowci_col = NULL,
+                               upci_col = NULL) {
+  moduleServer(
+    id,
+    function(input, output, session) {
+      
+      ns <- session$ns
+      
+      # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      # render chart once on initial load -----
+      # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      
+      # Chart is created based on default selections when the app loads
+      # wrapping in isolate() ensures this code doesn't run again -
+      # all subsequent updates are done using highcharter proxy functions
+      output$trend_chart <- renderHighchart({
+        
+        isolate({
+          
+          # data to plot
+          df <- r_data()
+          
+          # create line chart
+          hc <- highchart() |>
+            hc_add_series(id = "line_series", type = "line", name = y_col, data = df[[y_col]]) |>
+            hc_xAxis(
+              categories = unique(df[[x_col]]),
+              # only plot first and last year
+              labels = list(
+                rotation = 0, 
+                style = list(
+                  textOverflow = 'none'
+                  ),
+                formatter = JS("function() {
+               if (this.isFirst || this.isLast) {
+                 return this.value;
+               } else {
+                 return '';
+               }
+             }")
+              )) |>
+            hc_colors(c(phsstyles::phs_colors("phs-magenta"))) |>
+            hc_chart(marginRight = 15) |>
+            hc_legend(enabled = FALSE) |>
+            hc_add_theme(theme) # theme is from global script
+          
+          
+          # add confidence intervals if switched on by default
+          if("ci_switch" %in% names(r_chart_controls)){
+            if(isTRUE(r_chart_controls$ci_switch)){
+              
+              hc <- hc |>
+                hc_add_series(
+                  id = "ci_series",
+                  linked_to = "line_series",
+                  data = purrr::map2(r_data()[[lowci_col]], r_data()[[upci_col]], ~ c(.x, .y)),
+                  type = "arearange",
+                  fillOpacity = 0.2,
+                  enableMouseTracking = FALSE, 
+                  showInLegend = FALSE,
+                  zIndex = -1, 
+                  marker = list(
+                    enabled = FALSE,
+                    states = list(
+                      hover = list(
+                        enabled = FALSE
+                      )
+                    )
+                  )
+                  
+                )
+              
+            }
+          }
+          
+          # start y-axis at 0 if switched on by default
+          if("zero_yaxis_switch" %in% names(r_chart_controls)){
+            if(isTRUE(r_chart_controls$zero_yaxis_switch)){
+              hc <- hc|>
+                hc_yAxis(min = 0)
+            }
+          }
+          
+          
+          # remove animation
+          hc <- hc |>
+            hc_plotOptions(series = list(animation = FALSE)) |>
+            hc_chart(animation = FALSE)
+          
+          hc
+          
+          
+        })
+      })
+      
+      
+      
+      # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      # Update chart using proxy functions -------------
+      # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      
+      # highcharter proxy functions let you update an already built chart without re-rendering
+      # from scratch - faster way update a chart in response to user input: 
+      # https://jkunst.com/highcharter/reference/index.html#shiny-and-proxy-functions
+      
+      
+      
+      ## a. Updates in response to r_data changing -----
+      # i.e. updating the data that is plotted
+      
+      # whenever the reactive dataset is updated, update the chart:
+      observeEvent(r_data(), {
+        
+        # update the x-axis categories
+        hc <- highchartProxy(ns("trend_chart")) |>
+          hcpxy_update(xAxis = list(categories = unique(r_data()[[x_col]])), redraw = FALSE)
+        
+        # update the y-axis values
+        hc <- hc|>
+          hcpxy_update_series(id = "line_series", data = r_data()[[y_col]], redraw = FALSE)
+        
+        
+        # update ci_switch series (if ci_switch is on)
+        if("ci_switch" %in% names(r_chart_controls)){
+          if(isTRUE(r_chart_controls$ci_switch)){
+            
+            hc <- hc |>
+              hcpxy_update_series(
+                id = "ci_series",
+                data = purrr::map2(r_data()[[lowci_col]], r_data()[[upci_col]], ~ c(.x, .y)), redraw = FALSE)
+            
+          }
+        }
+        
+        # redraw once all chart updates done
+        hcpxy_redraw(hc)
+        
+        
+      }, ignoreInit = TRUE)
+      
+      
+      
+      ## b. Updates in response to r_chart_controls changing -----
+      # i.e. adding/removing parts of the chart
+      
+      
+      # adding/removing ci series
+      observeEvent(r_chart_controls$ci_switch, {
+        
+        hc <- highchartProxy(ns("trend_chart"))
+        
+        if(isTRUE(r_chart_controls$ci_switch)){
+          
+          hcpxy_add_series(
+            hc,
+            id = "ci_series",
+            linked_to = "line_series",
+            data = purrr::map2(r_data()[[lowci_col]], r_data()[[upci_col]], ~ c(.x, .y)),
+            type = "arearange",
+            fillOpacity = 0.2,
+            enableMouseTracking = FALSE, 
+            showInLegend = FALSE,
+            zIndex = -1, 
+            marker = list(
+              enabled = FALSE,
+              states = list(
+                hover = list(
+                  enabled = FALSE
+                )
+              )
+            )
+          )
+        } else {
+          hcpxy_remove_series(hc, id = "ci_series")
+        }
+        
+      }, ignoreInit = TRUE)
+      
+      
+      
+      # starting y-axis at 0
+      observeEvent(r_chart_controls$zero_yaxis_switch, {
+        highchartProxy(ns("trend_chart")) |>
+          hcpxy_update(
+            yAxis = list(min = if (isTRUE(r_chart_controls$zero_yaxis_switch)) 0 else NULL)
+          )
+      }, ignoreInit = TRUE)
+      
+      
+    }
+  )
+}

--- a/shiny_app/modules/filters/chart_controls_mod.R
+++ b/shiny_app/modules/filters/chart_controls_mod.R
@@ -97,7 +97,7 @@ chart_controls_mod_UI <- function(id,
 #'
 #' @param id Character string. The module's namespace ID (should match the UI function).
 #'
-#' @return Returns the result of moduleServer().
+#' @return Returns a **reactiveValues** object
 #'
 
 #' # copy in server:
@@ -168,8 +168,9 @@ chart_controls_mod_server <- function(id) {
         names(rv),
         ~ {!is.null(rv[[.x]]) & identical(rv[[.x]], rv_init[[.x]])}
       )
-
-      setBookmarkExclude(c(exclusions, "chart_settings_btn")) # apply exclusions alongside the chart settings button which should always be excluded!
+      
+      # apply exclusions alongside the chart settings button which should always be excluded!
+      setBookmarkExclude(c(exclusions, "chart_settings_btn")) 
 
     })
 
@@ -189,45 +190,45 @@ chart_controls_mod_server <- function(id) {
 # library(shiny)
 # library(bslib)
 
-shinyApp(
-  ui = function(request){
-    page(
-      layout_column_wrap(
-        div(
-          p("Card with inputs module:"),
-          bslib::navset_card_pill(
-            nav_panel("Chart", "placeholder"),
-            nav_spacer(),
-            chart_controls_mod_UI(id = "example")
-            )
-          ),
-          div(
-            p("The values returned from the module:"),
-            verbatimTextOutput("results"),
-          )
-        ),
-      div(
-        p("The URL that is updated whenever the bookmark button is pressed. If user doesn't change the
-                default values of the switches, they won't appear in the URL, otherwise they will."),
-        textOutput("url"),
-        bookmarkButton()
-      )
-      )
-    },
-  server = function(input, output, session) {
-
-  selections <- chart_controls_mod_server(id = "example")
-
-  output$results <- renderPrint({
-    shiny::reactiveValuesToList(selections)
-  })
-
-  onBookmarked(function(url) {
-    output$url <- renderText({
-      paste("url:", url)
-    })
-  })
-
-  },
-  enableBookmarking = "url"
-)
+# shinyApp(
+#   ui = function(request){
+#     page(
+#       layout_column_wrap(
+#         div(
+#           p("Card with inputs module:"),
+#           bslib::navset_card_pill(
+#             nav_panel("Chart", "placeholder"),
+#             nav_spacer(),
+#             chart_controls_mod_UI(id = "example")
+#             )
+#           ),
+#           div(
+#             p("The values returned from the module:"),
+#             verbatimTextOutput("results"),
+#           )
+#         ),
+#       div(
+#         p("The URL that is updated whenever the bookmark button is pressed. If user doesn't change the
+#                 default values of the switches, they won't appear in the URL, otherwise they will."),
+#         textOutput("url"),
+#         bookmarkButton()
+#       )
+#       )
+#     },
+#   server = function(input, output, session) {
+# 
+#   selections <- chart_controls_mod_server(id = "example")
+# 
+#   output$results <- renderPrint({
+#     shiny::reactiveValuesToList(selections)
+#   })
+# 
+#   onBookmarked(function(url) {
+#     output$url <- renderText({
+#       paste("url:", url)
+#     })
+#   })
+# 
+#   },
+#   enableBookmarking = "url"
+# )

--- a/shiny_app/modules/filters/chart_controls_mod.R
+++ b/shiny_app/modules/filters/chart_controls_mod.R
@@ -1,0 +1,233 @@
+#' Chart Controls Module
+#'
+#' A Shiny module that creates chart controls inside a popover and returns their value
+#' (confidence intervals switch, y-axis at 0 switch, average switch)
+#' The number of controls to include is optional
+#'
+#' @name chart_controls_mod
+
+# UI Function ----
+
+#' Chart Controls Module UI
+#'
+#' Creates collection of input_switches which can be used to amend charts
+#'
+#' @param id Character string. The module's namespace ID
+#' @param controls Named vector. Name of controls to include and whether should be TRUE/FALSE on initial load. Optional
+#' arg which when not used adds all 3 controls. Only need to use if want a different default than those listed below and/or only 
+#' want to include use some of the controls
+
+
+#'
+#' @return collection of bslib input_switches
+#'
+#' copy in UI:
+#' chart_controls_mod_UI(id = "simd_chart_controls")
+#'
+
+
+
+
+chart_controls_mod_UI <- function(id,
+                                  controls = c(ci_switch = FALSE, avg_switch = FALSE, zero_yaxis_switch = TRUE)) {
+  
+  # namespace id
+  ns <- NS(id)
+  
+  
+  # input labels
+  labels <- c(
+    ci_switch = "Include confidence intervals",
+    avg_switch = "Include average",
+    zero_yaxis_switch = "Start y-axis at zero"
+  )
+  
+  
+  # create between 1-3 inputs
+  # (depending on how many passed to 'controls' arg)
+  # if argument not in use all 3 will be included
+  # .y is the name of the input (e.g. ci_switch)
+  # .x is the default value assigned to that input (e.g. TRUE or FALSE)
+  inputs <- imap(controls, ~ {
+    input_switch(
+      id = ns(.y),
+      label = labels[[.y]],
+      value = .x
+    )
+  })
+  
+  
+  # add inputs to popover within nav item
+  nav_item(
+    popover(
+      title = "Chart settings",
+      trigger = actionButton(
+        inputId = ns("chart_settings_btn"),
+        label = "Settings",
+        icon = icon("gear"),
+        class = "btn-sm" # i.e button small 
+      ),
+      inputs
+    )
+  )
+  
+}
+
+
+# Server Function ----
+
+#' Chart controls Module Server
+#'
+#' Server logic for the chart controls module:
+#'
+#' Manages the state of the chart‑control switches created in the UI function. 
+#' It tracks both the user's current selections and the initial default values
+#'
+#' The function:
+#'   a. stores initial value of each switch when app first loads (`rv_init`)
+#'   b. updates reactive values object (`rv`) whenever the user changes any control
+#'   c. compares current selections to their defaults so that unchanged controls
+#'     can be excluded from Shiny bookmarking, helping to keep the URL shorter;
+#'   d. returns the reactive Values object (`rv`)containing the current state of all
+#'     controls
+#'
+#' These returned reactive values can be passed to other modules or server logic
+#' to dynamically adjust chart appearance based on user‑selection.
+
+#'
+#' @param id Character string. The module's namespace ID (should match the UI function).
+#'
+#' @return Returns the result of moduleServer().
+#'
+
+#' # copy in server:
+#' chart_controls_mod_server(id = "simd_chart")
+
+
+chart_controls_mod_server <- function(id) {
+  moduleServer(id, function(input, output, session) {
+
+
+    # input ids of switches created in UI
+    input_ids <- c("ci_switch", "avg_switch", "zero_yaxis_switch")
+
+
+    # object to store and return user selections
+    rv <- reactiveValues(
+      ci_switch = NULL,
+      avg_switch = NULL ,
+      zero_yaxis_switch = NULL
+    )
+
+    # object to store default selections when app loads
+    # (this is only updated once)
+    rv_init <- reactiveValues(
+      ci_switch = NULL,
+      avg_switch = NULL,
+      zero_yaxis_switch = NULL
+    )
+
+
+
+    # populate rv_init with default selections
+    # as soon as app loads (this code only runs once)
+    purrr::walk(input_ids, ~ {
+      observeEvent(input[[.x]], {
+        rv_init[[.x]] <- input[[.x]]
+      }, ignoreInit = FALSE, once = TRUE)
+    })
+
+
+    # store selections on both initial load and
+    # each time they change thereafter
+    # (these are the values the module returns to be passed
+    # to other modules for building charts)
+    observe({
+      purrr::walk(input_ids, ~ { rv[[.x]] <- input[[.x]]})
+    })
+
+
+
+    # dynamically set bookmark exclusions (only purpose of this code is to reduce the URL length)
+    # whenever rv changes (i.e. current user selections), compare against init_rv (i.e. default selections)
+    # If the currently selected value is the same as the default value, then exclude from any url
+
+    # Note doing exclusions inside a reactive context like an observer means it doesn't affect all
+    # instances of this module in the app - it's namespace aware.
+    # e.g. if using the chart controls mod twice and both uses have the CI switch turned off by default
+    # but user turns 1 of the CI switches on - that will be the only one captured in the URL (rather
+    # than all CI switches being included in the URL)
+
+    # small quirk with bookmark exclusions in modules:
+    # setBookmarkExclude overwrites other calls to setBookmarkExclude WITHIN the same module
+    #  https://github.com/rstudio/shiny/issues/2323
+    # This code set up gets around that issue by re-calculating which inputs to include/exclude
+    # each time any of them changes
+    observe({
+      exclusions <- purrr::keep(
+        names(rv),
+        ~ {!is.null(rv[[.x]]) & identical(rv[[.x]], rv_init[[.x]])}
+      )
+
+      setBookmarkExclude(c(exclusions, "chart_settings_btn")) # apply exclusions alongside the chart settings button which should always be excluded!
+
+    })
+
+
+
+    # return reactive values, ready to be used
+    # elsewhere in the app (e.g. within another module)
+    rv
+
+  })
+}
+
+
+
+# Module Usage Example ----
+# uncomment code below to run example shiny app
+# library(shiny)
+# library(bslib)
+
+shinyApp(
+  ui = function(request){
+    page(
+      layout_column_wrap(
+        div(
+          p("Card with inputs module:"),
+          bslib::navset_card_pill(
+            nav_panel("Chart", "placeholder"),
+            nav_spacer(),
+            chart_controls_mod_UI(id = "example")
+            )
+          ),
+          div(
+            p("The values returned from the module:"),
+            verbatimTextOutput("results"),
+          )
+        ),
+      div(
+        p("The URL that is updated whenever the bookmark button is pressed. If user doesn't change the
+                default values of the switches, they won't appear in the URL, otherwise they will."),
+        textOutput("url"),
+        bookmarkButton()
+      )
+      )
+    },
+  server = function(input, output, session) {
+
+  selections <- chart_controls_mod_server(id = "example")
+
+  output$results <- renderPrint({
+    shiny::reactiveValuesToList(selections)
+  })
+
+  onBookmarked(function(url) {
+    output$url <- renderText({
+      paste("url:", url)
+    })
+  })
+
+  },
+  enableBookmarking = "url"
+)

--- a/shiny_app/modules/visualisations/ltmhi_tab_mod.R
+++ b/shiny_app/modules/visualisations/ltmhi_tab_mod.R
@@ -188,7 +188,7 @@ ltmhi_UI <- function(id, ltmhi_dataset) {
                 textOutput(ns("simd_trend_subtitle"))
                 ),
                 # to be added
-               # multi_trend_chart_mod_UI(ns("simd_trend_chart"))
+                multi_trend_chart_mod_UI(ns("simd_trend_chart"))
                 ),
               nav_panel(title = "Table", "placeholder"),
               nav_spacer(),
@@ -263,7 +263,7 @@ ltmhi_UI <- function(id, ltmhi_dataset) {
             
             # PAR bar chart 
             navset_card_tab(
-              height = 500,
+              height = 550,
               id = ns("par_bar_card"),
               full_screen = TRUE,
               nav_panel(title = "Chart", 
@@ -280,7 +280,7 @@ ltmhi_UI <- function(id, ltmhi_dataset) {
             
             # PAR trend chart 
             navset_card_tab(
-              height = 500,
+              height = 550,
               id = ns("par_trend_card"),
               full_screen = TRUE,
               nav_panel(
@@ -617,10 +617,10 @@ ltmhi_Server <- function(id) {
       
       # SIMD trend chart
       # module to be added
-      # multi_trend_chart_mod_Server(id = "simd_trend_chart", r_data = r_ind_quintiles,
-      #                          r_chart_controls = simd_trend_controls,
-      #                          x_col = "trend_axis", y_col = "measure", lowci_col = "lowci", upci_col = "upci",
-      #                          group_col = "quintile", avg_col = "total")
+      multi_trend_chart_mod_Server(id = "simd_trend_chart", r_data = r_ind_quintiles,
+                               r_chart_controls = simd_trend_controls,
+                               x_col = "trend_axis", y_col = "measure", lowci_col = "lowci", upci_col = "upci",
+                               group_col = "quintile", avg_col = "total")
       
       
       
@@ -666,8 +666,8 @@ ltmhi_Server <- function(id) {
 
 
 
-# #For testing:
-# shinyApp(
+# # #For testing:
+#  shinyApp(
 #   ui = page_navbar(
 #     theme = phs_theme,
 #     navbar_options = list(bg = "#3F3685"),
@@ -682,7 +682,8 @@ ltmhi_Server <- function(id) {
 #   server = function(input, output, session){
 #     ltmhi_Server("example")
 #   }
-# )
+#  )
+
 
 
 

--- a/shiny_app/modules/visualisations/ltmhi_tab_mod.R
+++ b/shiny_app/modules/visualisations/ltmhi_tab_mod.R
@@ -1,3 +1,4 @@
+
 ltmhi_UI <- function(id, ltmhi_dataset) {
   ns <- NS(id)
  tagList(
@@ -24,6 +25,7 @@ ltmhi_UI <- function(id, ltmhi_dataset) {
 
     # sidebar navigaton menu with sub-sections
     layout_columns(
+      gap = "2rem",
       col_widths = c(3,9),
       
    
@@ -56,7 +58,7 @@ ltmhi_UI <- function(id, ltmhi_dataset) {
       div(
         class = "mb-5", # add bottom margin
         id = "headline-indicators",
-        h4("Headline indicators", class = "mb-4"),
+        h2("Headline indicators", class = "mb-4"),
         layout_column_wrap(
           width = "20rem",
           heights_equal = "row",
@@ -76,7 +78,7 @@ ltmhi_UI <- function(id, ltmhi_dataset) {
         class = "mb-5", # add bottom margin
         div(
           class = "mb-4",
-          h4("Summary table"),
+          h2("Summary table"),
           p("Recent trends in key indicators of health inequalities.")
           ),
         card(reactableOutput(ns("summary_tbl")))
@@ -98,7 +100,7 @@ ltmhi_UI <- function(id, ltmhi_dataset) {
         # py-2 and my-2 = top and bottom padding and margins
         div(
           class = "sticky-top bg-white py-2 my-2", 
-          h3("Explore indicators", class = "mb-4"),
+          h2("Explore indicators", class = "mb-4"),
           
           div(
             id = ns("filter_body"),
@@ -109,7 +111,8 @@ ltmhi_UI <- function(id, ltmhi_dataset) {
                 inputId = ns("ind_filter"),
                 label = NULL,
                 choices = split(ltmhi_lookup$indicator, ltmhi_lookup$domain),
-                width = "100%"
+                width = "100%",
+                selected = "Life expectancy, males"
               ),
               # type filter
               radioButtons(
@@ -146,55 +149,80 @@ ltmhi_UI <- function(id, ltmhi_dataset) {
         # container for cards with charts
         div(
           class = "m-1",
-          
+
           # Patterns of inequality charts
-          h5("Patterns of inequality", class = "mb-4"),
+          h3("Patterns of inequality", class = "mb-4"),
           
           layout_column_wrap(
             width = "20rem",
             
             # SIMD bar chart 
             navset_card_tab(
-              height = 450,
+              height = 500,
               id = ns("simd_bar_card"),
               full_screen = TRUE,
-              nav_panel(title = "Chart", "placeholder"),
+              nav_panel(
+                title = "Chart",
+                div(
+                h4(textOutput(ns("simd_bar_title"), container = span), class = "chart-header"),
+                textOutput(ns("simd_bar_subtitle"))
+                ),
+              bar_chart_mod_UI(ns("simd_bar_chart"))
+                ),
               nav_panel(title = "Table", "placeholder"),
               nav_spacer(),
               chart_controls_mod_UI(ns("simd_bar_controls"), controls = c(ci_switch = FALSE)),
               footer = card_footer(class = "d-flex justify-content-start", "placeholder")
-            ),
+            ), # close simd bar card
+            
             
             # SIMD trend chart 
             navset_card_tab(
-              height = 450,
+              height = 500,
               id = ns("simd_trend_card"),
               full_screen = TRUE,
-              nav_panel(title = "Chart", "placeholder"),
+              nav_panel(
+                title = "Chart", 
+                div(
+                h4(textOutput(ns("simd_trend_title"), container = span), class = "chart-header"),
+                textOutput(ns("simd_trend_subtitle"))
+                ),
+                # to be added
+               # multi_trend_chart_mod_UI(ns("simd_trend_chart"))
+                ),
               nav_panel(title = "Table", "placeholder"),
               nav_spacer(),
               chart_controls_mod_UI(ns("simd_trend_controls"), controls = c(ci_switch = FALSE, avg_switch = TRUE, zero_yaxis_switch = TRUE)),
               footer = card_footer(class = "d-flex justify-content-start", "placeholder")
-            )
-          ),
+          )# close simd trend card
+          ),  # close layout_column_wrap
           
-          
+          # add space
           br(),
           
           
           # Inequality gap charts
-          h5("Inequality gap", class = "mb-4"),
+          h3("Inequality gap", class = "mb-4"),
           
           layout_column_wrap(
             width = "20rem",
             
             # SII trend chart 
             navset_card_tab(
-              height = 450,
+              height = 600,
               id = ns("sii_card"),
               full_screen = TRUE,
-              nav_panel(title = "Chart", "placeholder"),
+              nav_panel(
+                title = "Chart",
+                div(
+                  h4("Inequalities over time: absolute differences", class = "chart-header"),                
+                  p(textOutput(ns("sii_subtitle"))),
+                  p("An increasing trend suggests the gap between the most and least deprived areas is growing ", actionLink(ns("sii_info_btn"), label = "learn more"))
+                ),
+                trend_chart_mod_UI(ns("sii_chart"))
+                ),
               nav_panel(title = "Table", "placeholder"),
+              nav_panel(title = "Help", about_sii),
               nav_spacer(),
               chart_controls_mod_UI(ns("sii_controls"), controls = c(ci_switch = FALSE, zero_yaxis_switch = TRUE)),
               footer = card_footer(class = "d-flex justify-content-start", "placeholder")
@@ -202,49 +230,74 @@ ltmhi_UI <- function(id, ltmhi_dataset) {
             
             # RII trend chart 
             navset_card_tab(
-              height = 450,
+              height = 600,
               id = ns("rii_card"),
               full_screen = TRUE,
-              nav_panel(title = "Chart", "placeholder"),
+              nav_panel(
+                title = "Chart", 
+                div(
+                  h4("Inequalities over time: relative differences", class = "chart-header"),
+                p("The differences between the most disadvantaged area and the overall average for Scotland (expressed as a percentage)."),
+                p("An increasing trend suggests that the gap between the most disadvantaged area and the average is growing ", actionLink(ns("rii_info_btn"), label = "learn more"))
+                ),
+                trend_chart_mod_UI(ns("rii_chart"))
+                ),
               nav_panel(title = "Table", "placeholder"),
+              nav_panel(title = "Help", about_rii),
               nav_spacer(),
               chart_controls_mod_UI(ns("rii_controls"), controls = c(ci_switch = FALSE, zero_yaxis_switch = TRUE)),
               footer = card_footer(class = "d-flex justify-content-start", "placeholder")
             )
-          ),
+            
+          ), # close layout_column_wrap
           
           
           br(),
           
           
           # Potential for imrpovement charts
-          h5("Potential for improvement", class = "mb-4"),
+          h3("Potential for improvement", class = "mb-4"),
           
           layout_column_wrap(
             width = "20rem",
             
             # PAR bar chart 
             navset_card_tab(
-              height = 450,
+              height = 500,
               id = ns("par_bar_card"),
               full_screen = TRUE,
-              nav_panel(title = "Chart", "placeholder"),
+              nav_panel(title = "Chart", 
+                        div(
+                        h4(textOutput(ns("par_bar_title")), class = "chart-header"),
+                        p(textOutput(ns("par_bar_subtitle"), inline = TRUE), actionLink(ns("par_bar_info_btn"), label = "learn more"))
+                        ),
+                        stacked_bar_chart_mod_UI(ns("par_bar_chart"))
+                        ),
               nav_panel(title = "Table", "placeholder"),
+              nav_panel(title = "Help", about_par),
               footer = card_footer(class = "d-flex justify-content-start", "placeholder")
             ),
             
             # PAR trend chart 
             navset_card_tab(
-              height = 450,
+              height = 500,
               id = ns("par_trend_card"),
               full_screen = TRUE,
-              nav_panel(title = "Chart", "placeholder"),
+              nav_panel(
+                title = "Chart", 
+                div(
+                  h4("Potential for improvement", class = "chart-header"),
+                p(textOutput(ns("par_trend_subtitle"), inline = TRUE), actionLink(ns("par_trend_info_btn"), label = "learn more"))
+                ),
+                trend_chart_mod_UI(ns("par_trend_chart"))
+                ),
               nav_panel(title = "Table", "placeholder"),
+              nav_panel(title = "Help", about_par_trend),
               nav_spacer(),
               chart_controls_mod_UI(ns("par_trend_controls"), controls = c(zero_yaxis_switch = TRUE)),
               footer = card_footer(class = "d-flex justify-content-start", "placeholder")
             )
-          )
+          ) # close layout_column_wrap
         ) # close container for charts
       ), # close explore indicators section
       
@@ -305,8 +358,7 @@ ltmhi_Server <- function(id) {
             sii_trend_period = colDef(show = FALSE),
             rii_trend_period = colDef(show = FALSE),
             comparison_period = colDef(show = FALSE),
-            description = colDef(show = FALSE),
-            
+
             
             # domain column
             domain = colDef(
@@ -435,8 +487,58 @@ ltmhi_Server <- function(id) {
       })
       
       
+      ## reactive datasets -------------------------------
       
-      # chart controls
+      # filter simd dataset by selected indicator (and transpose values so higher always worse)
+      r_ind_data <- reactive({
+        simd_dataset |>
+          filter(indicator == input$ind_filter & areaname == "Scotland" & sex == "Total" & quint_type == "sc_quin") |>
+          mutate(across(.cols=sii:abs_range,.fns=abs)) |>
+          arrange(year)
+      })
+      
+      # further filter by totals only (no simd splits - for SII/RII/PAR trend charts)
+      r_ind_totals <- reactive({
+        r_ind_data() |>
+          filter(quintile == "Total")
+      })
+      
+      # further filter by quintiles only (no totals - for SIMD trend chart)
+      r_ind_quintiles <- reactive({
+        r_ind_data() |>
+          group_by(year) |>
+          mutate(total = measure[quintile == "Total"]) |>
+          ungroup() |>
+          filter(quintile != "Total")
+      })
+      
+      # further filter by quintiles for latest year only (for SIMD bar chart )
+      r_ind_quintiles_max <- reactive({
+        r_ind_data() |>
+          filter(quintile != "Total") |>
+          filter(year == max(year))
+      })
+      
+      r_ind_quintiles_par <- reactive({
+        r_ind_data() |>
+        filter(quintile != "Total") |>
+          filter(year == max(year)) |>
+        mutate(highest_measure= case_when(quintile==qmax ~ measure, TRUE ~ 0),
+               lowest_measure= case_when(quintile==qmin ~ measure, TRUE ~0),
+               highest=max(highest_measure),
+               lowest=max(lowest_measure),
+               baseline=case_when(interpret=="L" ~ lowest,
+                                  interpret=="H" ~ measure),
+               `attributable to inequality`=case_when(interpret=="L" ~ abs(measure-baseline),
+                                                      (interpret=="H" ~ abs(measure-highest)))) |>
+        pivot_longer(cols = c("attributable to inequality", "baseline"), names_to = "measure_name")
+      })
+      
+      
+
+      
+      
+      ##  chart controls ----------------------------------
       # these objects store user selection from each cards chart controls
       # as reactiveValues which can then be used to update the charts accordingly
       # each one contains 3 values. If the input wasn't used in the UI the returned value
@@ -452,6 +554,109 @@ ltmhi_Server <- function(id) {
       par_trend_controls <- chart_controls_mod_server("par_trend_controls")
       
       
+      
+      # Chart titles ---------------
+      
+      # dynamic chart titles
+      r_titles <- reactive({
+        max_year <- r_ind_quintiles_max()$trend_axis[1]
+        min_year <- r_ind_totals()$trend_axis[1]
+        
+        list(
+          simd_bar = paste(input$ind_filter, "by SIMD quintile,", max_year),
+          simd_trend = paste(input$ind_filter, "by SIMD quintile,", min_year, "-", max_year),
+          par_bar = paste("Attributable to inequality,", max_year)
+        )
+      })
+      
+      
+      # dynamic subtitles
+      r_subtitles <- reactive({
+        
+        measure <- r_ind_data()$type_definition[1]
+        indicator <- input$ind_filter
+        
+        list(
+          simd_bar = measure,
+          simd_trend = measure,
+          sii = paste0("The difference between most and least deprived areas (expressed as ", measure, ")."),
+          par_bar = paste("The portion of", indicator, "which could be attributed to socioeconomic inequalities."),
+          par_trend = paste("How much (%)", indicator, "could be improved if the levels of the 
+          least deprived area were experienced across the whole population.")
+        )
+        
+      })
+
+      
+      # render chart titles
+      output$simd_bar_title <- renderText({r_titles()$simd_bar})
+      output$simd_trend_title <- renderText({r_titles()$simd_trend})
+      output$par_bar_title <- renderText({r_titles()$par_bar})
+      
+      
+      # render chart subtitles
+      output$simd_bar_subtitle <- renderText({r_subtitles()$simd_bar})
+      output$simd_trend_subtitle <- renderText({r_subtitles()$simd_trend})
+      output$sii_subtitle <- renderText({r_subtitles()$sii})
+      output$par_bar_subtitle <- renderText({r_subtitles()$par_bar})
+      output$par_trend_subtitle <- renderText({r_subtitles()$par_trend})
+
+      
+      
+      
+      # charts -----
+      
+      
+      # SIMD snapshot chart
+      bar_chart_mod_Server(id = "simd_bar_chart",
+                           r_data = r_ind_quintiles_max,
+                           r_chart_controls = simd_bar_controls,
+                           x_col = "quintile", y_col = "measure", lowci_col = "lowci", upci_col = "upci"
+                           )
+      
+      
+      # SIMD trend chart
+      # module to be added
+      # multi_trend_chart_mod_Server(id = "simd_trend_chart", r_data = r_ind_quintiles,
+      #                          r_chart_controls = simd_trend_controls,
+      #                          x_col = "trend_axis", y_col = "measure", lowci_col = "lowci", upci_col = "upci",
+      #                          group_col = "quintile", avg_col = "total")
+      
+      
+      
+      # Relative Index of Inequality (RII) trend chart
+      trend_chart_mod_Server(id = "rii_chart",
+                         r_data = r_ind_totals,
+                         r_chart_controls = rii_controls,
+                         x_col = "trend_axis", y_col = "rii_int", lowci_col = "lowci_rii_int", upci_col = "upci_rii_int"
+      )
+      
+      
+      # Slope Index of Inequality (SII) trend chart
+      trend_chart_mod_Server(id = "sii_chart",
+                         r_data = r_ind_totals,
+                         r_chart_controls = sii_controls,
+                         x_col = "trend_axis", y_col = "sii", lowci_col = "lowci_sii", upci_col = "upci_sii"
+      )
+      
+      
+
+      # Population attributable Risk (PAR) bar chart
+      stacked_bar_chart_mod_Server(id = "par_bar_chart", r_data = r_ind_quintiles_par,
+                                   x_col = "quintile", y_col = "value", group_col = "measure_name")
+      
+      
+      # Population Attributable Risk (PAR) trend chart
+      trend_chart_mod_Server(id = "par_trend_chart",
+                             r_data = r_ind_totals,
+                             r_chart_controls = par_trend_controls,
+                             x_col = "trend_axis", y_col = "par"
+      )
+      
+      
+
+      
+      
 
     }
   )
@@ -461,10 +666,11 @@ ltmhi_Server <- function(id) {
 
 
 
-# For testing:
-
+# #For testing:
 # shinyApp(
 #   ui = page_navbar(
+#     theme = phs_theme,
+#     navbar_options = list(bg = "#3F3685"),
 #     fillable = FALSE,
 #     header = useShinyjs(),
 #     nav_panel(

--- a/shiny_app/modules/visualisations/ltmhi_tab_mod.R
+++ b/shiny_app/modules/visualisations/ltmhi_tab_mod.R
@@ -36,10 +36,10 @@ ltmhi_UI <- function(id, ltmhi_dataset) {
         h4("Contents"),
         tags$ul(
           class = "list-group gap-3 list-unstyled",
-          tags$li(a(href = "#section-1", "Headline indicators")),
-          tags$li(a(href = "#section-2", "Summary table")),
-          tags$li(a(href = "#section-3", "Explore Indicators")),
-          tags$li(a(href = "#section-4", "About"))
+          tags$li(a(href = "#headline-indicators", "Headline indicators")),
+          tags$li(a(href = "#summary-table", "Summary table")),
+          tags$li(a(href = "#explore-indicators", "Explore Indicators")),
+          tags$li(a(href = "#about", "About"))
         ),
         hr()
       ), # close menu 
@@ -50,11 +50,12 @@ ltmhi_UI <- function(id, ltmhi_dataset) {
      # ~~~~~~~~~~~~~~~~~~~~~
      # right:
       div(
-        class = "pt-4 gap-5", # add top padding and gap between each section 
+        class = "pt-4", # add top padding
      
       # Section 1: Headline indicators --------------
       div(
-        id = "section-1",
+        class = "mb-5", # add bottom margin
+        id = "headline-indicators",
         h4("Headline indicators", class = "mb-4"),
         layout_column_wrap(
           width = "20rem",
@@ -71,7 +72,8 @@ ltmhi_UI <- function(id, ltmhi_dataset) {
 
       # Section 2: Summary table ----------------
       div(
-        id = "section-2",
+        id = "summary-table",
+        class = "mb-5", # add bottom margin
         div(
           class = "mb-4",
           h4("Summary table"),
@@ -79,11 +81,16 @@ ltmhi_UI <- function(id, ltmhi_dataset) {
           ),
         card(reactableOutput(ns("summary_tbl")))
         ), # close summary table section 
+      
+      
+      # horizontal line
+      hr(),
 
 
       # Section 3: Explore indicators section ----------------
       div(
-        id = "section-3",
+        id = "explore-indicators",
+        class = "mb-5", # add bottom margin
         
         # panel with indicators
         # sticky-top prevents panel from moving when scrolling
@@ -238,8 +245,9 @@ ltmhi_UI <- function(id, ltmhi_dataset) {
       
       # About section -----------------------
       div(
+        id = "about",
         class = "mb-5",
-        h4("About", class = "fw-bold mb-4"),
+        h4("About", class = "mb-4"),
         div(style = "height:800px", "Placeholder")
         )
       
@@ -321,7 +329,7 @@ ltmhi_Server <- function(id) {
               html = TRUE,
               cell = function(value){
                 tags$a(
-                  href = "#section-3",
+                  href = "#explore-indicators",
                   value,
                   # when link is clicked, update input$indicator_clicked with the name of the indicator
                   # which will trigger an observeEvent() that is spying on this input run in order to
@@ -427,7 +435,6 @@ ltmhi_Server <- function(id) {
 
 
 # For testing:
-
 
 # shinyApp(
 #   ui = page_navbar(

--- a/shiny_app/modules/visualisations/ltmhi_tab_mod.R
+++ b/shiny_app/modules/visualisations/ltmhi_tab_mod.R
@@ -160,6 +160,8 @@ ltmhi_UI <- function(id, ltmhi_dataset) {
               full_screen = TRUE,
               nav_panel(title = "Chart", "placeholder"),
               nav_panel(title = "Table", "placeholder"),
+              nav_spacer(),
+              chart_controls_mod_UI(ns("simd_bar_controls"), controls = c(ci_switch = FALSE)),
               footer = card_footer(class = "d-flex justify-content-start", "placeholder")
             ),
             
@@ -170,6 +172,8 @@ ltmhi_UI <- function(id, ltmhi_dataset) {
               full_screen = TRUE,
               nav_panel(title = "Chart", "placeholder"),
               nav_panel(title = "Table", "placeholder"),
+              nav_spacer(),
+              chart_controls_mod_UI(ns("simd_trend_controls"), controls = c(ci_switch = FALSE, avg_switch = TRUE, zero_yaxis_switch = TRUE)),
               footer = card_footer(class = "d-flex justify-content-start", "placeholder")
             )
           ),
@@ -191,6 +195,8 @@ ltmhi_UI <- function(id, ltmhi_dataset) {
               full_screen = TRUE,
               nav_panel(title = "Chart", "placeholder"),
               nav_panel(title = "Table", "placeholder"),
+              nav_spacer(),
+              chart_controls_mod_UI(ns("sii_controls"), controls = c(ci_switch = FALSE, zero_yaxis_switch = TRUE)),
               footer = card_footer(class = "d-flex justify-content-start", "placeholder")
             ),
             
@@ -201,6 +207,8 @@ ltmhi_UI <- function(id, ltmhi_dataset) {
               full_screen = TRUE,
               nav_panel(title = "Chart", "placeholder"),
               nav_panel(title = "Table", "placeholder"),
+              nav_spacer(),
+              chart_controls_mod_UI(ns("rii_controls"), controls = c(ci_switch = FALSE, zero_yaxis_switch = TRUE)),
               footer = card_footer(class = "d-flex justify-content-start", "placeholder")
             )
           ),
@@ -215,7 +223,7 @@ ltmhi_UI <- function(id, ltmhi_dataset) {
           layout_column_wrap(
             width = "20rem",
             
-            # SII trend chart 
+            # PAR bar chart 
             navset_card_tab(
               height = 450,
               id = ns("par_bar_card"),
@@ -225,13 +233,15 @@ ltmhi_UI <- function(id, ltmhi_dataset) {
               footer = card_footer(class = "d-flex justify-content-start", "placeholder")
             ),
             
-            # RII trend chart 
+            # PAR trend chart 
             navset_card_tab(
               height = 450,
               id = ns("par_trend_card"),
               full_screen = TRUE,
               nav_panel(title = "Chart", "placeholder"),
               nav_panel(title = "Table", "placeholder"),
+              nav_spacer(),
+              chart_controls_mod_UI(ns("par_trend_controls"), controls = c(zero_yaxis_switch = TRUE)),
               footer = card_footer(class = "d-flex justify-content-start", "placeholder")
             )
           )
@@ -426,6 +436,23 @@ ltmhi_Server <- function(id) {
       
       
       
+      # chart controls
+      # these objects store user selection from each cards chart controls
+      # as reactiveValues which can then be used to update the charts accordingly
+      # each one contains 3 values. If the input wasn't used in the UI the returned value
+      # will be NULL, e.g. for the SIMD bar chart when the app initially loads simd_bar_controls will be:
+      # simd_bar_controls$ci_switch = FALSE
+      # simd_bar_controls$avg_switch = NULL
+      # simd_bar_controls$zero_yaxis_switch = TRUE
+      
+      simd_bar_controls <- chart_controls_mod_server("simd_bar_controls")
+      simd_trend_controls <- chart_controls_mod_server("simd_trend_controls")
+      sii_controls <- chart_controls_mod_server("sii_controls")
+      rii_controls <- chart_controls_mod_server("rii_controls")
+      par_trend_controls <- chart_controls_mod_server("par_trend_controls")
+      
+      
+
     }
   )
 }

--- a/shiny_app/modules/visualisations/ltmhi_tab_mod.R
+++ b/shiny_app/modules/visualisations/ltmhi_tab_mod.R
@@ -1,116 +1,261 @@
 ltmhi_UI <- function(id, ltmhi_dataset) {
   ns <- NS(id)
-  page_fixed(
+ tagList(
 
-    # header and description
+   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   # Page header  ----
+   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   
     div(
-      class = "my-5", # add top and bottom margin
+      class = "p-2 mb-3", # add padding and bottom margin 
       h1("Long-term Monitoring of Health Inequalities in Scotland"),
-      p("Description")
+      # MM revisit: final link to report to be added
+      p("Access the", tags$a("full report with narrative", href = "placeholder", target = "_blank"), "on the Public Health Scotland website."),
+      bookmarkButton(class = "btn-sm")
     ),
 
     # horizonal line
     hr(),
-
+   
+   
+   # ~~~~~~~~~~~~~~~~~~~~~~
+   # Page contents ------
+   # ~~~~~~~~~~~~~~~~~~~~~~
 
     # sidebar navigaton menu with sub-sections
     layout_columns(
       col_widths = c(3,9),
       
-      
-      # left: contents menu 
+   
+    # ~~~~~~~~~~~~~~~~~~~~~
+    ## Contents Menu -----
+    # ~~~~~~~~~~~~~~~~~~~~~
+    # left:
       div(
-        class = "sticky-top p-4", # sticky-top prevents menu from dissappearing out of view when scrolling through content
+        class = "sticky-top p-4", # sticky-top prevents menu from scrolling out of view p-4
         h4("Contents"),
-        shinyWidgets::radioGroupButtons(
-          inputId = ns("sections"),
-          label = NULL,
-          status = "primary",
-          choices = c("Key points", "Summary table", "Explore indicators", "About"),
-          direction = "vertical",
-          width = "100%"
+        tags$ul(
+          class = "list-group gap-3 list-unstyled",
+          tags$li(a(href = "#section-1", "Headline indicators")),
+          tags$li(a(href = "#section-2", "Summary table")),
+          tags$li(a(href = "#section-3", "Explore Indicators")),
+          tags$li(a(href = "#section-4", "About"))
         ),
         hr()
-      ),
+      ), # close menu 
       
-      
-      # bslib navset_hidden is like conditionalPanel from shiny
-      # the nav_panel to display will then be updated, depending on what's selected
-      # from input above (input$sections)
-      navset_hidden(
-        id = ns("navs"),
-        
-
-
-      # Key points section
-      nav_panel(
-        title = "Key points",
-        class = "container",
-        p("placeholder")
-      ),
-
-
-      # Summary table section
-      nav_panel(
-        title = "Summary table",
-        class = "container",
-        card(reactableOutput(ns("summary_tbl")))
-      ),
-
-
-      # Explore indicators section
-      nav_panel(
-        title = "Explore indicators",
-        class = "container",
-        # indicator filter 
-        selectizeInput(
-          inputId = ns("ind_filter"),
-          label = NULL,
-          choices = split(ltmhi_lookup$indicator, ltmhi_lookup$domain)
+    
+     # ~~~~~~~~~~~~~~~~~~~~~
+     # Contents -----
+     # ~~~~~~~~~~~~~~~~~~~~~
+     # right:
+      div(
+        class = "pt-4 gap-5", # add top padding and gap between each section 
+     
+      # Section 1: Headline indicators --------------
+      div(
+        id = "section-1",
+        h4("Headline indicators", class = "mb-4"),
+        layout_column_wrap(
+          width = "20rem",
+          heights_equal = "row",
+          card("placeholder", full_screen = TRUE, height = 300),
+          card("placeholder", full_screen = TRUE, height = 300),
+          card("placeholder", full_screen = TRUE, height = 300),
+          card("placeholder", full_screen = TRUE, height = 300)
         )
-      ),
+      ), # close key points section 
+      
+      # horizontal line 
+      hr(),
+
+      # Section 2: Summary table ----------------
+      div(
+        id = "section-2",
+        div(
+          class = "mb-4",
+          h4("Summary table"),
+          p("Recent trends in key indicators of health inequalities.")
+          ),
+        card(reactableOutput(ns("summary_tbl")))
+        ), # close summary table section 
 
 
-      # About section
-      nav_panel(
-        title = "About",
-        class = "container",
-        p("placeholder")
-      )
+      # Section 3: Explore indicators section ----------------
+      div(
+        id = "section-3",
+        
+        # panel with indicators
+        # sticky-top prevents panel from moving when scrolling
+        # bg-white makes background white (to prevent seeing content scrolling past underneath the filters)
+        # py-2 and my-2 = top and bottom padding and margins
+        div(
+          class = "sticky-top bg-white py-2 my-2", 
+          h3("Explore indicators", class = "mb-4"),
+          
+          div(
+            id = ns("filter_body"),
+            class = "p-2",
+            layout_columns(
+              # indicator filter 
+              selectizeInput(
+                inputId = ns("ind_filter"),
+                label = NULL,
+                choices = split(ltmhi_lookup$indicator, ltmhi_lookup$domain),
+                width = "100%"
+              ),
+              # type filter
+              radioButtons(
+                inputId = ns("type_filter"),
+                choiceNames = c("Quintiles", "Deciles"),
+                choiceValues = c("sc_quin", "sc_decile"),
+                label = NULL,
+                inline = TRUE,
+                selected = "sc_quin"
+              ) |>
+                # temporary code: disable sc_decile option for now
+                # first iteration will only present data by quintiles
+                tagAppendChild(
+                  tags$script(
+                    sprintf(
+                      "$(function(){ $('#%s input[value=\"sc_decile\"]').prop('disabled', true); });",
+                      ns("type_filter")
+                    )
+                  )
+                )
+              )
+            ), #c lose filter_body div
+          
+          # button for opening/closing filters
+          actionButton(
+            inputId = ns("toggle_filters"),
+            class = "btn-sm position-absolute",
+            style = "right: 0.75rem; bottom: 0.5rem; z-index: 10;",
+            label = "Hide filters"
+          )
+        ), # close sticky filter panel
+        
+        
+        # container for cards with charts
+        div(
+          class = "m-1",
+          
+          # Patterns of inequality charts
+          h5("Patterns of inequality", class = "mb-4"),
+          
+          layout_column_wrap(
+            width = "20rem",
+            
+            # SIMD bar chart 
+            navset_card_tab(
+              height = 450,
+              id = ns("simd_bar_card"),
+              full_screen = TRUE,
+              nav_panel(title = "Chart", "placeholder"),
+              nav_panel(title = "Table", "placeholder"),
+              footer = card_footer(class = "d-flex justify-content-start", "placeholder")
+            ),
+            
+            # SIMD trend chart 
+            navset_card_tab(
+              height = 450,
+              id = ns("simd_trend_card"),
+              full_screen = TRUE,
+              nav_panel(title = "Chart", "placeholder"),
+              nav_panel(title = "Table", "placeholder"),
+              footer = card_footer(class = "d-flex justify-content-start", "placeholder")
+            )
+          ),
+          
+          
+          br(),
+          
+          
+          # Inequality gap charts
+          h5("Inequality gap", class = "mb-4"),
+          
+          layout_column_wrap(
+            width = "20rem",
+            
+            # SII trend chart 
+            navset_card_tab(
+              height = 450,
+              id = ns("sii_card"),
+              full_screen = TRUE,
+              nav_panel(title = "Chart", "placeholder"),
+              nav_panel(title = "Table", "placeholder"),
+              footer = card_footer(class = "d-flex justify-content-start", "placeholder")
+            ),
+            
+            # RII trend chart 
+            navset_card_tab(
+              height = 450,
+              id = ns("rii_card"),
+              full_screen = TRUE,
+              nav_panel(title = "Chart", "placeholder"),
+              nav_panel(title = "Table", "placeholder"),
+              footer = card_footer(class = "d-flex justify-content-start", "placeholder")
+            )
+          ),
+          
+          
+          br(),
+          
+          
+          # Potential for imrpovement charts
+          h5("Potential for improvement", class = "mb-4"),
+          
+          layout_column_wrap(
+            width = "20rem",
+            
+            # SII trend chart 
+            navset_card_tab(
+              height = 450,
+              id = ns("par_bar_card"),
+              full_screen = TRUE,
+              nav_panel(title = "Chart", "placeholder"),
+              nav_panel(title = "Table", "placeholder"),
+              footer = card_footer(class = "d-flex justify-content-start", "placeholder")
+            ),
+            
+            # RII trend chart 
+            navset_card_tab(
+              height = 450,
+              id = ns("par_trend_card"),
+              full_screen = TRUE,
+              nav_panel(title = "Chart", "placeholder"),
+              nav_panel(title = "Table", "placeholder"),
+              footer = card_footer(class = "d-flex justify-content-start", "placeholder")
+            )
+          )
+        ) # close container for charts
+      ), # close explore indicators section
+      
+      
+      # horizontal line
+      hr(),
+      
+      
+      # About section -----------------------
+      div(
+        class = "mb-5",
+        h4("About", class = "fw-bold mb-4"),
+        div(style = "height:800px", "Placeholder")
+        )
+      
+      ) # close right hand side section
+    ) # close layout_colums for left-menu and right-content
+ ) # close tagList
 
-    ) # close navset_hidden
-    ) # close layout columns 
+} # close function 
 
-  )
-}
+
 
 ltmhi_Server <- function(id) {
   moduleServer(
     id,
     function(input, output, session) {
-      
-      
-      # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      # navigation ------
-      # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      
-      observeEvent(input$sections, {
-        
-        section_ids <- c("Key points", "Summary table", "Explore indicators", "About")
-        
-        walk(section_ids, function(id) {
-          if(input$sections == id){
-            nav_show(id = "navs", target = id, select = TRUE)
-          } else {
-            nav_hide(id = "navs", target = id)
-          }
-        })
-      })
-      
-      
-      
-      
       # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       # Summary table server code ----
       # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -244,12 +389,7 @@ ltmhi_Server <- function(id) {
       # update selection from indicator filter in 'explore indicators' section 
       # whenever link clicked in summary table (i.e. when input$indicator_clicked changes)
       observeEvent(input$indicator_clicked, {
-        
-        shinyWidgets::updateRadioGroupButtons(
-          inputId = "sections",
-          selected = "Explore indicators"
-        )
-          
+
         updateSelectizeInput(
           session = session,
           inputId = "ind_filter",
@@ -257,6 +397,24 @@ ltmhi_Server <- function(id) {
         )
       })
       
+      
+      
+      # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      # Explore indicators server code ------
+      # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      
+      # open/close panel with filters when show/hide filter
+      # button is clicked and update buttons label accordingly
+      observeEvent(input$toggle_filters, {
+        shinyjs::toggle(id = "filter_body")
+        
+        if(input$toggle_filters %% 2 != 0){
+          updateActionButton(inputId = "toggle_filters", label = "Show filters")
+        } else {
+          updateActionButton(inputId = "toggle_filters", label = "Hide filters")
+        }
+        
+      })
       
       
       
@@ -273,6 +431,8 @@ ltmhi_Server <- function(id) {
 
 # shinyApp(
 #   ui = page_navbar(
+#     fillable = FALSE,
+#     header = useShinyjs(),
 #     nav_panel(
 #       class = "container-xxl",
 #       title = "National profile",

--- a/shiny_app/modules/visualisations/ltmhi_tab_mod.R
+++ b/shiny_app/modules/visualisations/ltmhi_tab_mod.R
@@ -1,3 +1,13 @@
+##########################################################################.
+# MODULE: Long Term Monitioring of Health Inequalities (LTMHI) module ---- 
+# Prepares nav panel which displays LTMHI information .
+##########################################################################.
+
+
+#######################################################.
+## MODULE UI ----
+#######################################################.
+
 
 ltmhi_UI <- function(id, ltmhi_dataset) {
   ns <- NS(id)
@@ -321,6 +331,9 @@ ltmhi_UI <- function(id, ltmhi_dataset) {
 } # close function 
 
 
+#######################################################.
+## MODULE SERVER ----
+#######################################################.
 
 ltmhi_Server <- function(id) {
   moduleServer(
@@ -449,7 +462,10 @@ ltmhi_Server <- function(id) {
                 
                 div(class = paste0("badge rounded-pill ms-auto bg-", colour), value)
               }
-            )
+            )            ,
+            
+            # Hide a column called 'description' so that not visible in table
+           description = colDef(show = F)
           )
         )
       })

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -218,7 +218,7 @@ function(input, output, session) {
 
   
    # running module for the long-term monitoring of HE tab
-   # ltmhi_Server(id = "ltmhi")
+   ltmhi_Server(id = "ltmhi")
   
   
   # # ############################################.

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -218,7 +218,7 @@ function(input, output, session) {
 
   
    # running module for the long-term monitoring of HE tab
-   # ltmi_Server(id = "ltmhi")
+   # ltmhi_Server(id = "ltmhi")
   
   
   # # ############################################.

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -218,7 +218,7 @@ function(input, output, session) {
 
   
    # running module for the long-term monitoring of HE tab
-   ltmhi_Server(id = "ltmhi")
+   #ltmhi_Server(id = "ltmhi")
   
   
   # # ############################################.

--- a/shiny_app/ui.R
+++ b/shiny_app/ui.R
@@ -310,15 +310,15 @@ page_navbar(
   # Currently only contains tab for a national profile 
   # (which supplements the long-term monitoring of HE in Scotland report)
   # but will eventually include local profiles
-  # nav_menu(
-  #   title = "Health inequalities",
-  #   nav_panel(
-  #     title = "National profile",  
-  #     value = "shi_tab",
-  #     ltmhi_UI("ltmhi")
-  #   )
-  # ),
-  
+  nav_menu(
+    title = "Health inequalities",
+    nav_panel(
+      title = "National profile",
+      value = "shi_tab",
+      ltmhi_UI("ltmhi")
+    )
+  ),
+
   nav_spacer(), # add space to navbar 
   
   ########################################.

--- a/shiny_app/ui.R
+++ b/shiny_app/ui.R
@@ -310,14 +310,14 @@ page_navbar(
   # Currently only contains tab for a national profile 
   # (which supplements the long-term monitoring of HE in Scotland report)
   # but will eventually include local profiles
-  nav_menu(
-    title = "Health inequalities",
-    nav_panel(
-      title = "National profile",
-      value = "shi_tab",
-      ltmhi_UI("ltmhi")
-    )
-  ),
+  # nav_menu(
+  #   title = "Health inequalities",
+  #   nav_panel(
+  #     title = "National profile",
+  #     value = "shi_tab",
+  #     ltmhi_UI("ltmhi")
+  #   )
+  # ),
 
   nav_spacer(), # add space to navbar 
   


### PR DESCRIPTION
Adding in chart controls, titles, subtitles and charts alongside a modified layout so everything sits on the one page.

I've added modules for each chart type using highcharter proxy functions which let you manipulate the chart when user input changes without re-rendering it each time: https://jkunst.com/highcharter/reference/index.html#shiny-and-proxy-functions. Some of the chart module code still needs tidied up and more notes etc added so wouldn't pay too much attention to it just now.

Have also added a chart controls module for the popovers with controls that go in each card to avoid duplication since basically every chart in the app has them and will help with the size of bookmarked urls. There is code in the module to exclude any of these inputs from a URL if a user hasn't changed the default value, since we only need to re-apply filter selections which have been changed by the user when opening a bookmarked URL. There's an example app in at bottom of that module that demonstrates this.

All of these modules can eventually be added to the other tabs of the app when we want to roll out bookmarking and/or speed up the charts.

Main things still to be done are adding downloads/share buttons, bookmarking and adding in key points. Then should just be some tinkering around the edges.

Let me know if you want to chat through anything.

