### PR TITLE
grouping before creating qmin and qmax cols

### DIFF
--- a/data_preparation/functions/create_dataset.R
+++ b/data_preparation/functions/create_dataset.R
@@ -158,16 +158,21 @@ create_dataset <- function(folder,
   if (dataset == "deprivation"){
     data <- data |>
       mutate(
-        qmax = ifelse(sum(is.na(measure))==5, as.character(NA), quintile[which.max(measure)]), # which quintile contains highest rate/value
-        qmin = ifelse(sum(is.na(measure))==5, as.character(NA), quintile[which.min(measure)]) # which quintile contains lowest rate/value
-      ) |>
-      dplyr::mutate(
         quintile = dplyr::recode(
           quintile,
           "1" = "1 - most deprived", 
           "5" = "5 - least deprived"
         )
-      )
+      ) |>
+      # create 2 new columns which are populated with the highest and lowest value
+      # these are used for the calculation for PAR charts
+      group_by(ind_id, year, quint_type, code) |>
+      mutate(
+        qmax = ifelse(sum(is.na(measure))==5, as.character(NA), quintile[which.max(measure)]), # which quintile contains highest rate/value
+        qmin = ifelse(sum(is.na(measure))==5, as.character(NA), quintile[which.min(measure)]) # which quintile contains lowest rate/value
+      ) |>
+      ungroup()
+
   }
   
   


### PR DESCRIPTION
As Liz pointed out the PAR charts were looking funky.

This was an error on my part caused by the recent changes to data prep scripts - 2 columns (qmin and qmax) which are required for the calculation for the par charts were not being created properly during the data prep process. Just added in a group_by() and should now be fixed if you re-run data prep.