### PR TITLE
add temporary notice

### DIFF
--- a/data_preparation/1_ScotPHO_profiles_data_preparation.R
+++ b/data_preparation/1_ScotPHO_profiles_data_preparation.R
@@ -213,8 +213,10 @@ climate_popgrp <- create_dataset(
 )
 
 
+# temporary step until climate pop_grp indicators available again
+popgrp_dataset <-scotpho_popgrp
 # combine all popgroup datasets
-popgrp_dataset <- rbind(scotpho_popgrp, climate_popgrp)
+#popgrp_dataset <- rbind(scotpho_popgrp, climate_popgrp)
 
 
 # save popgroup dataset in this projects data folder, ready to be used in the app

--- a/shiny_app/ui.R
+++ b/shiny_app/ui.R
@@ -263,14 +263,32 @@ page_navbar(
                                  # only display this when Climate change is selected
                                  # contains links to info about profile and related publication
                                  conditionalPanel(condition = "input.profile_choices == 'Climate'",
-                                                  div(style = "padding: 10px; background-color: #F5ECF4;",
-                                                      p(bs_icon("info-circle-fill", size = "1.2em"), " Read more about the new",
-                                                        actionLink(inputId = "cli_about_link", label = "climate profile"), 
-                                                        " and access the associated report on the Public Health Scotland website:", 
-                                                        tags$a("‘Heat impacts on health in Scotland: Deaths 2005-2024’", href = "https://publichealthscotland.scot/publications/heat-impacts-on-health-in-scotland/heat-impacts-on-health-in-scotland-28-october-2025/", target = "_blank")
+                                                  # temporarily comment out until the climate team correct indicators
+                                                  # div(style = "padding: 10px; background-color: #F5ECF4;",
+                                                  #     p(bs_icon("info-circle-fill", size = "1.2em"), " Read more about the new",
+                                                  #       actionLink(inputId = "cli_about_link", label = "climate profile"), 
+                                                  #       " and access the associated report on the Public Health Scotland website:", 
+                                                  #       tags$a("‘Heat impacts on health in Scotland: Deaths 2005-2024’", href = "https://publichealthscotland.scot/publications/heat-impacts-on-health-in-scotland/heat-impacts-on-health-in-scotland-28-october-2025/", target = "_blank")
+                                                  #       )
+                                                  #     )
+                                                  
+                                                  # temporary notice about climate profile indicators being removed
+                                                  card(
+                                                    class = "m-2",
+                                                    card_header(bs_icon("info-circle-fill", size = "1.2em"),"Important notice",class = "info-box-header"),
+                                                    card_body(
+                                                      p("The", tags$a("‘Heat impacts on health in Scotland: Deaths 2005-2024’", href = "https://publichealthscotland.scot/publications/heat-impacts-on-health-in-scotland/heat-impacts-on-health-in-scotland-28-october-2025/", target = "_blank"),
+                                                        "has been temporarily removed from the public domain while the Climate Analyst Team investigates an error in the code. 
+                                                        It is expected to have affected indicators related to risk thresholds and modelled deaths estimates. 
+                                                        These have temporarily been removed from the profiles tool. The Climate Analyst Team is working to fix the error 
+                                                        and update the results accordingly. The corrected report will be released in May. For any questions, please contact", 
+                                                        tags$a("phs.climateanalysis@phs.scot", href = "mailto::phs.climateanalysis@phs.scot", target = "_blank")
                                                         )
                                                       )
-                                                  ),
+                                                    )
+                                                  ), # close conditional panel
+                                                      
+
                                  trend_mod_ui("trends")),
                        
                        # rank sub-tab 


### PR DESCRIPTION
Adding in climate notice. Have also made the 3 affected indicators inactive in climate techdoc and removed the files from their climate shiny folder.

@abigap01 adding you for awareness that some of the climate indicators have been temporarily removed as the climate team need to amend and re-publish their heat impacts publication.
