### PR TITLE
ER - automating available_geographies (for the indicator definitions page)

### DIFF
--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -283,44 +283,6 @@ areatype_list <- c("Alcohol & drug partnership", #S11
                    "Police division", #S32
                    "Scotland") #S00
 
-# getting available_geographies from the data that has been read in, rather than the techdoc column:
-
-# function to get the geogs for each indicator
-get_geogs <- function(df) {
-  df %>%  
-    mutate(geog = substr(code, 1, 3)) %>%
-    select(ind_id, geog) %>%
-    unique()
-}
-
-# run the function
-main_geogs <- get_geogs(main_dataset)
-simd_geogs <- get_geogs(simd_dataset)
-popgroup_geogs <- get_geogs(popgroup_dataset)
-
-# combine the data and create and available_geographies column
-all_geogs <- rbind(main_geogs, simd_geogs, popgroup_geogs) %>% 
-  unique() %>%
-  mutate(geog = factor(geog,
-                       levels = c("S00", "S08", "S32", "S12", "S37", "S11", "S99", "S02"),
-                       labels = c("Scotland", #S00
-                                  "Health board",  #S08
-                                  "Police division", #S32
-                                  "Council area", #S12
-                                  "HSC partnership",  #S37
-                                  "Alcohol & drug partnership", #S11
-                                  "HSC locality", #S99
-                                  "Intermediate zone" #S02
-                                  ))) %>%
-  arrange(ind_id, geog) %>%
-  group_by(ind_id) %>%
-  summarise(available_geographies = paste0(geog, collapse=", ")) %>%
-  ungroup()
-
-# replace existing column in techdoc (as this could have typos/missing/incorrect data)
-techdoc <- techdoc %>% 
-  select(-available_geographies) %>%
-  merge(y=all_geogs, by="ind_id")
 
 
 # 5. Dashboard theme ---------------------------------------------------------------

--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -274,16 +274,53 @@ pd_list <- sort(geo_lookup$areaname[geo_lookup$areatype=="Police division"])
 
 
 # geography areatypes
-areatype_list <- c("Alcohol & drug partnership", 
-                   "Council area", 
-                   "Health board",  
-                   "HSC locality", 
-                   "HSC partnership",  
-                   "Intermediate zone",
-                   "Police division",
-                   "Scotland")
+areatype_list <- c("Alcohol & drug partnership", #S11
+                   "Council area", #S12
+                   "Health board",  #S08
+                   "HSC locality", #S99
+                   "HSC partnership",  #S37
+                   "Intermediate zone", #S02
+                   "Police division", #S32
+                   "Scotland") #S00
 
+# getting available_geographies from the data that has been read in, rather than the techdoc column:
 
+# function to get the geogs for each indicator
+get_geogs <- function(df) {
+  df %>%  
+    mutate(geog = substr(code, 1, 3)) %>%
+    select(ind_id, geog) %>%
+    unique()
+}
+
+# run the function
+main_geogs <- get_geogs(main_dataset)
+simd_geogs <- get_geogs(simd_dataset)
+popgroup_geogs <- get_geogs(popgroup_dataset)
+
+# combine the data and create and available_geographies column
+all_geogs <- rbind(main_geogs, simd_geogs, popgroup_geogs) %>% 
+  unique() %>%
+  mutate(geog = factor(geog,
+                       levels = c("S00", "S08", "S32", "S12", "S37", "S11", "S99", "S02"),
+                       labels = c("Scotland", #S00
+                                  "Health board",  #S08
+                                  "Police division", #S32
+                                  "Council area", #S12
+                                  "HSC partnership",  #S37
+                                  "Alcohol & drug partnership", #S11
+                                  "HSC locality", #S99
+                                  "Intermediate zone" #S02
+                                  ))) %>%
+  arrange(ind_id, geog) %>%
+  group_by(ind_id) %>%
+  summarise(available_geographies = paste0(geog, collapse=", ")) %>%
+  ungroup()
+
+# replace existing column in techdoc (as this could have typos/missing/incorrect data)
+techdoc <- techdoc %>% 
+  select(-available_geographies) %>%
+  merge(y=all_geogs, by="ind_id")
 
 
 # 5. Dashboard theme ---------------------------------------------------------------

--- a/shiny_app/modules/visualisations/indicator_definitions_mod.R
+++ b/shiny_app/modules/visualisations/indicator_definitions_mod.R
@@ -80,7 +80,7 @@ definitions_tab_Server <- function(id) {
           x
         } else {
           x <- x |>
-            filter(grepl(paste(input$geo_search, collapse="|"), available_geographies))
+            filter(ind_id %in% main_dataset$ind_id[main_dataset$areatype %in% input$geo_search])
         }
         
         


### PR DESCRIPTION
Motivated by an error found in multiple indicators in the techdoc: these weren't being filtered correctly by the Indicator definitions geog filter because their available_geographies column didn't exactly match those in the app's areatype_list. E.g., filter by council and the string "suicide" and none currently turn up, whereas there should be two, because both have "CA" rather than "Council area" in the techdoc. The suggested change replaces that error-prone column with standardised area type names extracted from the data themselves.   