### PR TITLE
ER - using profile long names in Indicator definitions table

### DIFF
--- a/data_preparation/functions/prepare_techdoc.R
+++ b/data_preparation/functions/prepare_techdoc.R
@@ -62,6 +62,27 @@ prepare_techdoc <- function(filepath,
   techdoc <- techdoc |>
     filter(active %in% c("A", "AR", if(test_indicators) "T"))
   
+
+  
+  # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  # Make a profiles column containing only the profile long name -----
+  # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  
+  techdoc <- techdoc |>
+    mutate(profiles = gsub("-.*;", "; ", profile_domain)) |> #drop domains
+    mutate(profiles = gsub("-.*", "; ", profiles)) |> #drop domains that don't have ; after them
+    mutate(profiles = stringr::str_replace_all(profiles, c("HWB" = "Health & Wellbeing",                   
+                                                           "CWB" = "Population Health",                    
+                                                           "CLI" = "Climate",                             
+                                                           "MEN" = "Adult Mental Health",                  
+                                                           "CMH" = "Children & Young People Mental Health",
+                                                           "CYP" = "Children & Young People",             
+                                                           "TOB" = "Tobacco",                              
+                                                           "ALC" = "Alcohol",                               
+                                                           "DRG" = "Drugs",
+                                                           "PHY" = "Physical Activity",
+                                                           "POP" = "Population",
+                                                           "SHI" = "Health inequalities")))
   
   
   
@@ -83,6 +104,7 @@ prepare_techdoc <- function(filepath,
       
       # profile(s) and domain(s) indicator belongs to
       profile_domain,
+      profiles,
       
       # data source details (why 2 cols?)
       data_source,

--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -259,7 +259,25 @@ profile_filter_choices <- names(Filter(function(x) x$active == TRUE & x$nav_id =
 # into 'active' and 'archived' in the indicator filters across the other tabs
 archived_indicators <- techdoc$ind_id[techdoc$active == "AR"]
 
+# profile list for techdoc
+techdoc <- techdoc %>%
+  mutate(profiles = gsub("-.*;", "; ", profile_domain)) %>% #drop domains
+  mutate(profiles = gsub("-.*", "; ", profiles)) %>% #drop domains that don't have ; after them
+  mutate(profiles = stringr::str_replace_all(profiles, c("HWB" = "Health & Wellbeing",                   
+                                               "CWB" = "Population Health",                    
+                                               "CLI" = "Climate",                             
+                                               "MEN" = "Adult Mental Health",                  
+                                               "CMH" = "Children & Young People Mental Health",
+                                               "CYP" = "Children & Young People",             
+                                               "TOB" = "Tobacco",                              
+                                               "ALC" = "Alcohol",                               
+                                               "DRG" = "Drugs",
+                                               "PHY" = "Physical Activity",
+                                               "POP" = "Population",
+                                               "SHI" = "Health inequalities")))
+  
 
+                            
 
 # Area names by geography type  including HB, CA, HSCP, alcohol and drugs partnership
 # HSC partnership names - also used as the choices for an additional parent area filter 

--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -259,25 +259,6 @@ profile_filter_choices <- names(Filter(function(x) x$active == TRUE & x$nav_id =
 # into 'active' and 'archived' in the indicator filters across the other tabs
 archived_indicators <- techdoc$ind_id[techdoc$active == "AR"]
 
-# profile list for techdoc
-techdoc <- techdoc %>%
-  mutate(profiles = gsub("-.*;", "; ", profile_domain)) %>% #drop domains
-  mutate(profiles = gsub("-.*", "; ", profiles)) %>% #drop domains that don't have ; after them
-  mutate(profiles = stringr::str_replace_all(profiles, c("HWB" = "Health & Wellbeing",                   
-                                               "CWB" = "Population Health",                    
-                                               "CLI" = "Climate",                             
-                                               "MEN" = "Adult Mental Health",                  
-                                               "CMH" = "Children & Young People Mental Health",
-                                               "CYP" = "Children & Young People",             
-                                               "TOB" = "Tobacco",                              
-                                               "ALC" = "Alcohol",                               
-                                               "DRG" = "Drugs",
-                                               "PHY" = "Physical Activity",
-                                               "POP" = "Population",
-                                               "SHI" = "Health inequalities")))
-  
-
-                            
 
 # Area names by geography type  including HB, CA, HSCP, alcohol and drugs partnership
 # HSC partnership names - also used as the choices for an additional parent area filter 

--- a/shiny_app/modules/visualisations/indicator_definitions_mod.R
+++ b/shiny_app/modules/visualisations/indicator_definitions_mod.R
@@ -147,7 +147,7 @@ definitions_tab_Server <- function(id) {
                      
                      <div>
                      <h4 class = 'metadata-header'>Profiles</h4>
-                     ${rowInfo.values['profile_domain']}
+                     ${rowInfo.values['profiles']}
                      </div>
                      
                      <br>
@@ -243,6 +243,7 @@ definitions_tab_Server <- function(id) {
             # however most of them are used to populate the information when a row is expanded
             ind_id = colDef(show = F),
             profile_domain = colDef(show = F),
+            profiles = colDef(show = F),
             indicator_definition = colDef(show = F),
             data_source = colDef(show = F),
             source_details = colDef(show = F),


### PR DESCRIPTION
Motivated by scrutinising user-friendliness of the app ahead of my user workshop. The profile codes in the table were not very readable. Have replaced with the profile long names (without their domain name). There is likely a neater way to do this.