### PR TITLE
ER - sort order for indicators in All Indicators profile

### DIFF
--- a/shiny_app/modules/filters/indicator_filter_mod.R
+++ b/shiny_app/modules/filters/indicator_filter_mod.R
@@ -26,7 +26,7 @@ indicator_filter_mod_server <- function(id, filtered_data, geo_selections, selec
       dt <- dt[areatype == geo_selections()$areatype & areaname == geo_selections()$areaname]
       
       if(selected_profile()$full_name == "All Indicators"){
-        choices <- unique(dt$indicator)
+        choices <- sort(unique(dt$indicator))
       } else {
       
       # select columns and get unique rows


### PR DESCRIPTION
Couldn't make sense of the previous ordering or lack of when looking at All Indicators, so thought that alphabetical on indicator name made sense. Now I think it is easier to find particular indicators (as well as typing in the search box, which I always forget).