### PR TITLE
fix "replace old geocode" function

### DIFF
--- a/data_preparation/functions/replace_old_geography_codes.R
+++ b/data_preparation/functions/replace_old_geography_codes.R
@@ -1,4 +1,4 @@
-#' `replace_old_geography_codes` replaces 2011 Health board/Council area codes with 2019 equivalents
+#' `replace_old_geography_codes` replaces old 2011 Health board/Council area codes with 2019 equivalents
 #'
 #' @param data the dataframe to replace codes in
 #' @param col_name the column name containing geography codes
@@ -12,24 +12,26 @@
 
 
 replace_old_geography_codes <- function(data, col_name) {
-  
+
   data <- data |> 
-    mutate(!!col_name := recode(!!rlang::sym(col_name), 
-                                # Council area code changes
-                                "S12000015" = 'S12000047', # Fife
-                                "S12000024" = 'S12000048', # Perth and Kinross
-                                "S12000046" = 'S12000049', # Glasgow City
-                                "S12000044" = 'S12000050', # North Lanarkshire
-                                # Health board code changes
-                                "S08000018" = 'S08000029', # NHS Fife
-                                "S08000027" = 'S08000030', # NHS Tayside
-                                "S08000021" ='S08000031', # NHS Greater Glasgow & Clyde
-                                "S08000023" = 'S08000032', # NHS Lanarkshire
-                                # HSCP code changes
-                                "S37000014" ='S37000032', # Fife
-                                "S37000023" ='S37000033', # Perth and Kinross
-                                "S37000015" ='S37000034', # Glasgow City
-                                "S37000021" ='S37000035')) # North Lanarkshire
+    mutate(!!rlang::sym(col_name) := case_match(!!rlang::sym(col_name), 
+                                        # Council area code changes
+                                        "S12000015" ~ "S12000047", # Fife
+                                        "S12000024" ~ "S12000048", # Perth and Kinross
+                                        "S12000046" ~ "S12000049", # Glasgow City
+                                        "S12000044" ~ "S12000050", # North Lanarkshire
+                                        # Health board code changes
+                                        "S08000018" ~ 'S08000029', # NHS Fife
+                                        "S08000027" ~ 'S08000030', # NHS Tayside
+                                        "S08000021" ~'S08000031', # NHS Greater Glasgow & Clyde
+                                        "S08000023" ~ "S08000032", # NHS Lanarkshire
+                                        # HSCP code changes
+                                        "S37000014" ~'S37000032', # Fife
+                                        "S37000023" ~'S37000033', # Perth and Kinross
+                                        "S37000015" ~'S37000034', # Glasgow City
+                                        "S37000021" ~'S37000035', # North Lanarkshire
+                                        .default = !!rlang::sym(col_name))) 
+  
   
   
   return(data)


### PR DESCRIPTION
The data prep steps didn't seem to be correcting at least one indicator where old gss geocodes were present in the indicator data file. Instead of correcting the codes it was converting the old codes to NA (which i think might have been dropped).
Drug related deaths is one indicator where 2002-2005 data affected for NHS board like fife or lanarkshire. Correcting the function means that complete time series correctly will appear in the tool