### PR TITLE
MM data table tab fixes

### DIFF
--- a/data_preparation/1_ScotPHO_profiles_data_preparation.R
+++ b/data_preparation/1_ScotPHO_profiles_data_preparation.R
@@ -150,7 +150,7 @@ scotpho_main <- create_dataset(
   file_suffix = "_shiny.csv", 
   test_indicators = FALSE,
   profile_filter = NULL,
-  file_snapshot = TRUE # set to TRUE if deploying
+  file_snapshot = FALSE # set to TRUE if deploying
 )
 
 
@@ -163,7 +163,7 @@ climate_main <- create_dataset(
   file_suffix = "_shiny.parquet",
   test_indicators = FALSE,
   profile_filter = NULL,
-  file_snapshot = TRUE # set to TRUE if deploying
+  file_snapshot = FALSE # set to TRUE if deploying
 )
 
 # combine all main datasets 
@@ -195,7 +195,7 @@ scotpho_popgrp <- create_dataset(
   file_suffix = "popgrp.csv",
   test_indicators = FALSE,
   profile_filter = NULL,
-  file_snapshot = TRUE # set to TRUE if deploying
+  file_snapshot = FALSE # set to TRUE if deploying
 )
 
 
@@ -209,7 +209,7 @@ climate_popgrp <- create_dataset(
   file_suffix = "popgrp.parquet",
   test_indicators = FALSE,
   profile_filter = NULL,
-  file_snapshot = TRUE # set to true if deploying
+  file_snapshot = FALSE # set to true if deploying
 )
 
 
@@ -244,7 +244,7 @@ depr_dataset <- create_dataset(
   file_suffix = "ineq.rds",
   test_indicators = FALSE,
   profile_filter = NULL,
-  file_snapshot = TRUE # set to true if deploying
+  file_snapshot = FALSE # set to true if deploying
 )
 
 # MM Nov 2025 - temporarily remove scotland decile data

--- a/data_preparation/1_ScotPHO_profiles_data_preparation.R
+++ b/data_preparation/1_ScotPHO_profiles_data_preparation.R
@@ -55,6 +55,7 @@ library(cli)
 library(rlang)
 library(tools)
 library(utils)
+library(shinyWidgets)
 
 
 ## Source functions ----

--- a/data_preparation/functions/update_geography_lookups.R
+++ b/data_preparation/functions/update_geography_lookups.R
@@ -55,38 +55,51 @@ create_geography_lookup <- function (folder){
 
 update_geography_hierachy <- function(folder){
   
+  # Go through each geography type and do the following:
   geo_list <- map(c("Scotland", "Health board", "Council area", "Alcohol & drug partnership", 
                     "HSC partnership", "Police division", "HSC locality", "Intermediate zone"), ~ {
 
     
-    data_x <- geo_lookup[geo_lookup$areatype == .x, ]
+    # a. filter the geo_lookup by that areatype
+    areatype_lookup <- geo_lookup[geo_lookup$areatype == .x, ]
     
+    # b. created a list for that areatype, in the format
+    # required for shinyWidgets::quercusInput() 
+    # create_tree is a function from the shiny Widgets package that
+    # creates choices for this input in the required format
+    
+    # if the areatype is scotland, create a list with just 1 level
     if (.x == "Scotland") {
       
       create_tree(
-        data = data_x,
-        levels    = "areatype",
+        data = areatype_lookup,
+        levels = "areatype",
         levels_id = "code"
       )
-      
+    
+    # if areatype is IZ/HSC locality, create list with 3 levels
     } else if (.x %in% c("Intermediate zone", "HSC locality")) {
       
       create_tree(
-        data = data_x,
-        levels    = c("areatype", "parent_area", "areaname"),
+        data = areatype_lookup,
+        levels = c("areatype", "parent_area", "areaname"),
         levels_id = c("areatype", "parent_area", "code")
       )
       
     } else {
       
+    
+      # otherwise if anything else (HB/CA etc) create list with 2 levels
       create_tree(
-        data = data_x,
-        levels    = c("areatype", "areaname"),
+        data = areatype_lookup,
+        levels = c("areatype", "areaname"),
         levels_id = c("areatype", "code")
       )
     }
-  }) |> reduce(c)
+  }) |> reduce(c) # reduce into one large nested list
     
+  
+  # save output
   saveRDS(geo_list, file.path(project_folder, "main_dataset_geography_nodes.rds"))
 }
 

--- a/data_preparation/functions/update_geography_lookups.R
+++ b/data_preparation/functions/update_geography_lookups.R
@@ -33,6 +33,7 @@ create_geography_lookup <- function (folder){
   
   # convert cols from factor to character and arrange alphabetically
   geo_lookup <- geo_lookup |>
+    select(-areaname_full) |> # drop column - not use anywhere in shiny app
     mutate(across(everything(), ~ as.character(.))) |>
     arrange(areatype, parent_area, areaname)
   

--- a/data_preparation/functions/update_geography_lookups.R
+++ b/data_preparation/functions/update_geography_lookups.R
@@ -34,7 +34,6 @@ create_geography_lookup <- function (folder){
   # convert cols from factor to character and arrange alphabetically
   geo_lookup <- geo_lookup |>
     select(-areaname_full) |> # drop column - not use anywhere in shiny app
-    mutate(across(everything(), ~ as.character(.))) |>
     arrange(areatype, parent_area, areaname)
   
   # save in local repo
@@ -55,6 +54,12 @@ create_geography_lookup <- function (folder){
 # to create the hierarchical geography filter in the sidebar.
 
 update_geography_hierachy <- function(folder){
+  
+  # get lookup 
+  geo_lookup <- readRDS(file.path(scotpho_folder, "Lookups/Geography/opt_geo_lookup.rds")) |>
+    # convert from factor to character otherwise produces massive file!
+    mutate(across(everything(), ~ as.character(.)))
+    
   
   # Go through each geography type and do the following:
   geo_list <- map(c("Scotland", "Health board", "Council area", "Alcohol & drug partnership", 

--- a/data_preparation/functions/update_geography_lookups.R
+++ b/data_preparation/functions/update_geography_lookups.R
@@ -29,45 +29,14 @@ create_geography_lookup <- function (folder){
   }
   
   # get lookup 
-  geo_lookup <- readRDS(file.path(scotpho_folder, "Lookups/Geography/opt_geo_lookup.rds")) |>
-    select(-areaname_full)
+  geo_lookup <- readRDS(file.path(scotpho_folder, "Lookups/Geography/opt_geo_lookup.rds"))
   
-  # arrange areatypes
+  # convert cols from factor to character and arrange alphabetically
   geo_lookup <- geo_lookup |>
-    mutate(areatype = factor(
-      areatype,
-      levels = c(
-        "Scotland",
-        "Health board",
-        "Council area",
-        "Alcohol & drug partnership",
-        "HSC partnership",
-        "HSC locality",
-        "Intermediate zone",
-        "Police division"
-      )
-    )) |>
+    mutate(across(everything(), ~ as.character(.))) |>
     arrange(areatype, parent_area, areaname)
   
-  # add additional column to the lookup that 
-  # contains the full geography path (e.g. Health board/NHS Ayrshire & Arran)
-  geo_lookup <- geo_lookup |>
-    mutate(
-      geo_path = paste(
-        areatype,
-        case_when(
-          areatype %in% c("Intermediate zone", "HSC locality") ~ parent_area,
-          TRUE ~ areaname
-        ),
-        case_when(
-          areatype %in% c("Intermediate zone", "HSC locality") ~ areaname,
-          TRUE ~ NA_character_
-        ),
-        sep = "/"
-      ),
-      geo_path = sub("/NA$", "", geo_path)
-    )
-  
+  # save in local repo
   saveRDS(geo_lookup, file.path(project_folder, "profiles_geo_lookup.rds"))
   
   # return geo_lookup outside of function
@@ -76,62 +45,48 @@ create_geography_lookup <- function (folder){
 }
 
 
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # 2. geography list -----
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # This lookup is used only on the data table tab of the app, in order
 # to create the hierarchical geography filter in the sidebar.
-# this code is lifted from the documentation for the 'jsTreeR' package 
-# (which is the package used to create the geography filter in the data table tab)
-# see examples here: https://www.rdocumentation.org/packages/jsTreeR/versions/1.1.0/topics/jstree-shiny 
 
-update_geography_hierachy <-function(folder){
+update_geography_hierachy <- function(folder){
   
-  # get unique geographies from geo lookup
-  leaves <- geo_lookup$geo_path 
-  
-  dfs <- lapply(strsplit(leaves, "/"), function(s){
-    item <-Reduce(function(a,b) paste0(a,"/",b), s[-1], s[1], accumulate = TRUE)
-    data.frame(
-      item = item,
-      parent = c("root", item[-length(item)]),
-      stringsAsFactors = FALSE
-    )
-  })
-  
-  
-  #dat <- dfs[[1]]
-  # for(i in 2:length(dfs)){
-  #   dat <- merge(dat, dfs[[i]], all = TRUE)
-  # }
-  
-  # amending function using 2 lines below to use rbind instead of merge 
-  # This allows parent nodes to be ordered based on how data is arranged before being passed to this function
-  # instead of alphabetically
-  dat <- do.call(rbind, dfs)
-  dat <- dat[!duplicated(dat), ]
-  
-  f <- function(parent){
-    i <- match(parent, dat$item)
-    item <- dat$item[i]
-    children <- dat$item[dat$parent==item]
-    label <- tail(strsplit(item, "/")[[1]], 1)
-    if(length(children)){
-      list(
-        text = label,
-        children = lapply(children, f),
-        icon =FALSE,
-        state = list(selected = FALSE, opened = FALSE )
+  geo_list <- map(c("Scotland", "Health board", "Council area", "Alcohol & drug partnership", 
+                    "HSC partnership", "Police division", "HSC locality", "Intermediate zone"), ~ {
+
+    
+    data_x <- geo_lookup[geo_lookup$areatype == .x, ]
+    
+    if (.x == "Scotland") {
+      
+      create_tree(
+        data = data_x,
+        levels    = "areatype",
+        levels_id = "code"
       )
-    }else{
-      list(text = label, type = "child",icon = FALSE,
-           state = list(selected = FALSE,opened = FALSE ))
+      
+    } else if (.x %in% c("Intermediate zone", "HSC locality")) {
+      
+      create_tree(
+        data = data_x,
+        levels    = c("areatype", "parent_area", "areaname"),
+        levels_id = c("areatype", "parent_area", "code")
+      )
+      
+    } else {
+      
+      create_tree(
+        data = data_x,
+        levels    = c("areatype", "areaname"),
+        levels_id = c("areatype", "code")
+      )
     }
-  }
-  
-  geo_list <- lapply(dat$item[dat$parent == "root"], f)
-  
+  }) |> reduce(c)
+    
   saveRDS(geo_list, file.path(project_folder, "main_dataset_geography_nodes.rds"))
 }
 

--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -16,13 +16,11 @@ library(reactable) # data tables
 library(highcharter) # visualisations
 library(data.table) # faster data wrangling
 library(dplyr) # data wrangling
-library(htmlwidgets) # for download buttons
 library(shinycssloaders) # for spinners when ui loading
 library(jsonlite) # for download data in json format/reading in .json shapefiles
 library(reactable) # for data tables
 library(leaflet) # for map
-library(jsTreeR) # for data tab geography filters
-library(shinyWidgets)
+library(shinyWidgets) # for various inputs (must be V0.9.1 or above)
 library(bsicons) # for icons
 library(cicerone) #for guided tours of tabs
 library(DT)

--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -11,6 +11,7 @@ library(bslib) # app layout functions/theming
 library(phsstyles) # for phs colour palette
 library(shinyjs) # for various functions to expand/collapse geography filters 
 library(htmltools) # for landing page template to read
+library(htmlwidgets) # unsure if being used - to be review 
 library(purrr) # needed for sourcing modules with map
 library(reactable) # data tables
 library(highcharter) # visualisations

--- a/shiny_app/modules/visualisations/data_table_tab_mod.R
+++ b/shiny_app/modules/visualisations/data_table_tab_mod.R
@@ -12,96 +12,144 @@
 
 data_tab_modUI <- function(id) {
   ns <- NS(id)
-  tagList(
-    page_sidebar(padding = 20, gap = 20,
-                       sidebar = sidebar(width = 300, padding = 20,
-                                         open = list(mobile = "always-above"), # make contents of side collapse on mobiles above main content
-                                         
-                                         # clear filters button
-                                         actionButton(ns("clear_table_filters"),
-                                                      label = "Clear all filters",
-                                                      icon ("eraser"),
-                                                      class = "down"),
-                                         
-                                         # dataset selection filter
-                                         radioButtons(
-                                           inputId = ns("dataset_selector"),
-                                           label = bslib::tooltip(
-                                             placement = "bottom",
-                                             trigger = list("Select a dataset",icon("info-circle")),
-                                                        "The main dataset contains data on all indicators at 
-                                                        various geography levels. The inequalities dataset is a smaller subset of indicators 
-                                             and geographies, which are split by SIMD quintiles and other measures of inequality 
-                                             (this dataset underpins the visualisations in the inequalities sub-tabs).", 
-                                           ),                                           choices = c("Main Dataset","Inequalities Dataset"),
-                                           selected = "Main Dataset" # default on main opt dataset
-                                         ),
+    page_sidebar(
+      sidebar = sidebar(
+        width = 400, 
+        open = list(mobile = "always-above"), # make contents of side collapse on mobiles above main content
+        bg = "#F8FAFC",
+        
+        # header and clear filters button
+        div(
+          class = "d-flex justify-content-between",
+          h4("Filters"),
+          actionButton(
+            inputId = ns("clear_table_filters"),
+            label = "Clear filters",
+            icon ("eraser"),
+            class = "btn-sm"
+            )
+          ),
+        
+        
+        # dataset selection filter
+        card(
+          card_header(
+            div("Dataset", span("*", class = "text-red")),
+            tooltip(
+              bs_icon("info-circle"),
+              "The main dataset contains data for all indicators at various geography levels.
+               The inequalities dataset is a smaller subset of indicators and geographies,
+               split by SIMD quintiles and other measures of inequality (this dataset underpins
+               the visualisations in the inequalities sub-tabs)."
+              )
+            ),
+          card_body(
+            helpText("Select a dataset to get started."),
+            radioButtons(
+              inputId = ns("dataset_selector"),
+              label = NULL,
+              choices = c("Main Dataset","Inequalities Dataset"),
+              selected = "Main Dataset" # default on main dataset
+            )
+          )
+        ),
+        
+        # quintile type filter (only if inequalities dataset is selected)
+        hidden(
+          div(
+            id = ns("inequality_extras"),
+            card(
+              card_header(
+                div("SIMD Quintile types", span("*", class = "text-red")),
+                tooltip(
+                  bs_icon("info-circle"),
+                  p("Scottish quintile 1 refers to the datazones containing the 20% most deprived population in Scotland. Local quintile 1 contains the datazones where the 20% most deprived population within a particular Health board or Council area reside."),
+                  p("Scottish quintiles therefore highlight inequalities between Scotland’s most and least deprived population, while local quintiles show inequalities within an area.")
+                )
+              ),
+              helpText("Select one or more quintile type."),
+              checkboxGroupInput(
+                inputId = ns("quint_type_selector"), 
+                label = NULL, 
+                choices = c("Local", "Scotland"),
+                selected = "Scotland" # default on scottish quintiles
+              )
+            )
+        )
+        ),
+        
 
-                                         # quintile type filter (only if inequalities dataset is selected)
-                                         conditionalPanel(
-                                           id = ns(id),
-                                           condition = "input['dataset_selector'] === 'Inequalities Dataset'",
-                                           radioGroupButtons(
-                                             inputId = ns("quint_type_selector"),
-                                             label = "Select quintile type",
-                                             choices = c("Local", "Scotland"),
-                                             selected = "Scotland" # default on max year for each indicator
-                                           )
-                                         ),
+        
+        # Geography filters
+        card(
+          card_header(
+            div("Geographies", span("*", class = "text-red"))
+          ),
+          card_body(
+            helpText("Use the '+' symbol to expand areatypes and the checkboxes to select areas. Selecting the checkbox next to an areatype will select all areas within that geography level."),
+            quercusInput(
+              inputId = ns("geography_selector"),
+              label = NULL,
+              choices = main_data_geo_nodes, # defined in global script
+              returnValue = "id", # return geography code instead of name 
+              width = "100%",
+              searchPlaceholder = "Type to search geographies",
+              searchEnabled = TRUE, # add search box 
+              showChildrenOnSearch = TRUE,
+              checkboxSelectionEnabled = TRUE, # add checkboxes
+              multiSelectEnabled = TRUE, # allow multiple selections
+              cascadeSelectChildren = TRUE # select all child areas when parent area selected
+            )
+          )
+        ),
                                          
-                                         # Geography filters
-                                         jstreeOutput(ns("geography_selector")),
-                                         
-                                         # profile filters
-                                         virtualSelectInput(inputId = ns("profile_selector"),
-                                                            label = "Select profile(s)",
-                                                            choices = profiles_list,
-                                                            disableSelectAll = FALSE,
-                                                            multiple = TRUE,
-                                                            search = TRUE,
-                                                            searchByStartsWith = TRUE,
-                                                            width = '100%',
-                                                            zIndex = 100),
-                                         
-                                         # indicator filters
-                                         virtualSelectInput(inputId = ns("indicator_selector"),
-                                                            label = "Select indicator(s)",
-                                                            noOptionsText = "Select atleast one geography to see what indicators are available",
-                                                            choices = NULL,
-                                                            disableSelectAll = TRUE,
-                                                            multiple = TRUE,
-                                                            search = TRUE,
-                                                            searchByStartsWith = TRUE,
-                                                            dropboxWrapper = "body",
-                                                            dropboxWidth = '400px',
-                                                            width = '100%',
-                                                            zIndex = 100),
-                                         
-                                         
-                                         # time period filter
-                                         radioGroupButtons(
-                                           inputId = ns("time_period_selector"),
-                                           label = "Select time period:",
-                                           choices = c("Latest available year", "All years"),
-                                           selected = "Latest available year"
-                                         )
-                                         
-                       ), # close sidebar
-                       
-                       h1("Download data"),
-                       p("Use the filters to build a data table, which can then be downloaded in various formats using the button below. 
-                         Please note that the table below is a preview. The downloaded dataset will contain more columns containing metadata 
-                         than are presented here."),
+        # profile filters
+        card(
+          card_header("Profiles", helpText("(optional)")),
+          card_body(
+            helpText("Filter dataset by profiles. Some profiles may be disabled depending on the dataset and geography selected."),
+            pickerInput(
+              inputId = ns("profile_selector"),
+              label = NULL,
+              choices = names(discard(profiles_list, ~ .x$short_name %in% c("ALL", "SHI"))),
+              multiple = TRUE,
+              options = list(container = "body")
+            )
+          )
+        ),
+        
+        # indicator filters
+        card(
+          card_header("Indicators", helpText("(optional)")),
+          helpText("Filter dataset by indicators. Indicator choices are dependent on previous selections."),
+          pickerInput(
+            inputId = ns("indicator_selector"),
+            label = NULL,
+            choices = NULL,
+            multiple = TRUE,
+            options = list(container = "body")
+          )
+        )
+        ), # close sidebar
+      
+      h1("Download data"),
+      p("Use the filters to build a data table, which can then be downloaded in various formats using the button below. 
+         The table below is a preview. The downloaded dataset will contain more columns containing metadata 
+         than are presented here."),
                  
                  
-                       # download data button
-                        download_data_btns_ui(id = ns("datatable_downloads")),
-                       # data table
-                       DTOutput(ns("data_tab_table"))
-                       
-        ) # close layout
+     # download data button
+     download_data_btns_ui(id = ns("datatable_downloads")),
+     
 
-  )
+     # data table
+     card(
+       card_header(p(textOutput(ns("row_count"), inline = TRUE), " rows")),
+       card_body(DTOutput(ns("data_tab_table")))
+     )
+     
+     ) # close layout
+
 }
 
 #######################################################.
@@ -112,10 +160,10 @@ data_tab_mod_Server <- function(id) {
   moduleServer(
     id,
     function(input, output, session) {
-      
+
       ns <- session$ns
-      
-      
+
+
       #############################.
       # REACTIVE DATASETS ----
       #############################.
@@ -127,109 +175,80 @@ data_tab_mod_Server <- function(id) {
                "Inequalities Dataset" = simd_dataset)
         })
       
-      
-      
-      # choices for geography filter, depending on what dataset is selected
-      # this is required because the deprivation dataset only has Scotland, CA and HB level data
-      GeographyNodes <- reactive({
-        if(input$dataset_selector == "Main Dataset") {
-          main_data_geo_nodes # full list of geographies
-        } else {
-          main_data_geo_nodes[c(1:3)] # scotland, hb and ca only 
-        }
-      })
-      
-      
-      # data to display in table /download 
+
+
+
+
+
+
+      # data to display in table /download
       tableData <- reactive({
-        
+
         # selected dataset
-        data <- selectedData() 
-        
+        data <- selectedData()
+
         # filter by selected geographies
-        paths <- sapply(input$geography_selector_checked_paths, `[[`, "path")
-        data <- data |> subset(geo_path %in% paths)
-        
-        
-        # filter by time period 
-        if(input$time_period_selector == "Latest available year") {
-          setDT(data) # switch to data.table format here as quicker than grouping using dplyr
-          data <- data[, .SD[year == max(year)], by = indicator]
-        } else data
-        
-        
+        data <- data[code %in% input$geography_selector]
+
+
         # filter by quint type (if inequalities dataset selected)
-        if(input$dataset_selector == "Inequalities Dataset") {
-          if(input$quint_type_selector == "Scotland") {
-            data <- data |> filter(quint_type == "sc_quin")
+        if(input$dataset_selector == "Inequalities Dataset"){
+        if(length(input$quint_type_selector) == 1){
+          if("Scotland" %in% input$quint_type_selector){
+          data <- data[quint_type == "sc_quin"]
           } else {
-            data <- data |> filter(quint_type != "sc_quin")
+          data <- data[quint_type != "sc_quin"]
           }
-        } else data
-        
-        
-        # if profile selected (but indicators have not been)
-        # then filter by selected profiles only 
-        if(isTruthy(input$profile_selector) & !isTruthy(input$indicator_selector)) {
-          if("All Indicators" %in% input$profile_selector) {
-            data } else {
-          profile_short_names <- paste(map_chr(input$profile_selector, ~ pluck(profiles_list, .x, "short_name")), collapse = "|")
-          
-          data <- data |>
-            filter(grepl(profile_short_names, profile_domain))
-            }
-          
-          
-          # if a profile has been selected (and some indicators too)
-          # then filter by profile and indicator
-        } else if(isTruthy(input$profile_selector) & isTruthy(input$indicator_selector)) {
-          profile_short_names <- paste(map_chr(input$profile_selector, ~ pluck(profiles_list, .x, "short_name")), collapse = "|")
-          
-          data <- data |>
-            filter(grepl(profile_short_names, profile_domain)) |>
-            filter(indicator %in% input$indicator_selector)
-          
-          
-          
-          # if no profile has been selected but some indicators have
-          # then filter by indicators only 
-        } else if(!isTruthy(input$profile_selector) & isTruthy(input$indicator_selector)) {
-          
-          data <- data |>
-            filter(indicator %in% input$indicator_selector)
-          
-        } else {
-          
-          # if nothings been selected from profile or indicator filter then return all available indicators
-          # for chosen dataset/geography/time period
-          data <- data
         }
-        
-        # rename some columns 
+        }
+
+        # further filter by profile (if any selected)
+        if(!is.null(input$profile_selector)){
+
+          # find short 3-letter profile names from profiles list
+          # in global script for selected indicator and create regex
+          # "e.g. DRG|ALC" and alcohol are selected
+          profile_regex <- profiles_list[input$profile_selector] |>
+            map_chr("short_name") |>
+            paste(collapse = "|")
+
+          # filter rows where any of short names found in profile_domain column
+          data <- data[grepl(profile_regex, profile_domain)]
+        }
+
+
+
+        # further filter by indicator (if any selected)
+        if(!is.null(input$indicator_selector)){
+          data <- data[indicator %in% input$indicator_selector]
+        }
+
+
+        # rename some columns
         data <- data |>
-          rename(area_code = code, 
-                 area_type = areatype, 
-                 area_name = areaname, 
-                 period = def_period, 
-                 upper_confidence_interval = upci, 
+          rename(area_code = code,
+                 area_type = areatype,
+                 area_name = areaname,
+                 period = def_period,
+                 upper_confidence_interval = upci,
                  lower_confidence_interval = lowci)
-        
+
         # columns to return if main dataset was selected
         if(input$dataset_selector == "Main Dataset") {
-          
+
           data <- data |>
             select(area_code, area_type, area_name, year, period, type_definition,
-                   indicator, numerator, measure, 
+                   indicator, numerator, measure,
                    upper_confidence_interval, lower_confidence_interval) } else {
-                     
+
                      # columns to return if inequalities dataset was selected
                      # note this requires some reshaping due to the format of the inequalities dataset
-                     
+
                      # all inequalities data
                      data <- data |>
                        rename(value = measure,
                               measure = type_definition)
-                     
+
                      # sii data
                      sii <- data |>
                        filter(quintile == "Total") |>
@@ -239,7 +258,7 @@ data_tab_mod_Server <- function(id) {
                        mutate(measure = "Slope index of inequality (SII)",
                               quintile = NULL
                        )
-                     
+
                      # rii data
                      rii <- data |>
                        filter(quintile == "Total") |>
@@ -248,7 +267,7 @@ data_tab_mod_Server <- function(id) {
                               lower_confidence_interval = lowci_rii) |>
                        mutate(measure = "Relative index of inequality (RII)",
                               quintile = NULL)
-                     
+
                      # par data
                      par <- data |>
                        filter(quintile == "Total") |>
@@ -257,169 +276,211 @@ data_tab_mod_Server <- function(id) {
                               lower_confidence_interval = lowci_rii_int) |>
                        mutate(measure = "Population attributable risk (PAR)",
                               quintile = NULL)
-                     
+
                      # different inequalities measures combined
                      data <- bind_rows(data, rii, sii, par) |>
-                       select(area_code, area_type, area_name, year, period, indicator, 
-                              quint_type, quintile, measure, value, upper_confidence_interval, 
+                       select(area_code, area_type, area_name, year, period, indicator,
+                              quint_type, quintile, measure, value, upper_confidence_interval,
                               lower_confidence_interval) |>
                        arrange(indicator, area_name, year)
                    }
-        
+
                   # add data source column
                   techdoc <- techdoc |>
                     select(indicator_name, data_source)
-                  
+
                   data <- data |>
                     left_join(techdoc, by = c("indicator" = "indicator_name"))
-        
+
       })
-      
-      
+
+
     #####################################.
     # DYNAMIC FILTERS ----
     #####################################.
-      
-      
-      # create geography filter using GeographyNodes() reactive object
-      # which stores available geographies, depending on what dataset was selected
-      output$geography_selector <- renderJstree({
-        jstree(
-          GeographyNodes(),
-          checkboxes = TRUE,
-          selectLeavesOnly = TRUE,
-          theme = "proton"
+
+
+      # Update geography choices depending on selected dataset
+      # (as only Scotland, HB and CA data available in inequalities dataset)
+      observeEvent(input$dataset_selector, {
+
+        # either return full list or only part of list containing scotland, HB, CA choices
+        valid_choices <- switch(
+          input$dataset_selector,
+          "Main Dataset" = main_data_geo_nodes,
+          "Inequalities Dataset" = main_data_geo_nodes[c(1:3)]
         )
+
+        # update filter with choices
+        updateQuercusInput(inputId = "geography_selector", choices = valid_choices)
+
       })
       
       
-      # update geography choices when required
-      observe({
-        jstreeUpdate(session, ns("geography_selector"), GeographyNodes())
-      })
-      
-      
-      # Update indicator filter choices based on dataset and geography selected
-      # (and further updating if profile also selected)
-      observe({
-        
-        # return selected geographies
-        paths <- sapply(input$geography_selector_checked_paths, `[[`, "path")
-        
-        # filter selected dataset by selected geographies
-        data <- selectedData() |>
-          subset(geo_path %in% paths)
-        
-        # create vector of available indicators
-        available_indicators <- unique(data$indicator)
-        
-        # Store the current selection of indicators (if there were any)
-        # i.e. if you've switched dataset but had previously selected some indicators
-        current_selected_indicators <- input$indicator_selector
-        
-        
-        # Further filter indicators if a profile is selected
-        if (!is.null(input$profile_selector)) {
-          
-          profile_filtered_data <- data |>
-            filter(grepl(paste(profiles_list[[input$profile_selector]]$short_name, collapse = "|"), profile_domain))
-          
-          
-          available_indicators <- unique(profile_filtered_data$indicator)
-          
+      # show/hide quintile type filter depending on selected dataset
+      observeEvent(input$dataset_selector, {
+        if(input$dataset_selector == "Inequalities Dataset"){
+          shinyjs::show("inequality_extras")
+        } else {
+          shinyjs::hide("inequality_extras")
         }
+      })
+      
+      # enable/disable quintile type filter depending on selecte geographies
+      # as only Scottish quintiles can be selected if no local areas selected
+      observeEvent(input$geography_selector, {
+        req(input$dataset_selector == "Inequalities Dataset")
+        req(input$geography_selector)
         
-        
-        # Update the filter choices
-        updateVirtualSelect(session = session,
-                            inputId = "indicator_selector",
-                            choices = available_indicators)
-        
-        # Reapply the previous selection if they are still valid
-        valid_selections <- intersect(current_selected_indicators, available_indicators)
-        
-        if (!is.null(valid_selections) && length(valid_selections) > 0) {
-          updateVirtualSelect(session = session,
-                              inputId = "indicator_selector",
-                              selected = valid_selections)
-          
+
+        if(length(input$geography_selector) == 1 & "S00000001" %in% input$geography_selector){
+          updateCheckboxGroupInput(
+            inputId = "quint_type_selector",
+            selected = "Scotland"
+          )
+          disable("quint_type_selector")
+        } else {
+          enable("quint_type_selector")
         }
+
+      })
+
+
+
+      # Update profile filter choices based on dataset and geography selected
+      observeEvent(c(input$geography_selector, selectedData()), {
+        req(input$geography_selector) # don't run until a geography has been selected
+
+        # further filter selected dataset by selected geographies
+        geo_profiles <- unique(selectedData()[code %in% input$geography_selector, profile_domain])
+
+        # get names of profiles excluding 'All Indicators' and 'Long-term Montitoring of HE'
+        # as we don't want these to be choices in the profiles filter
+        all_profiles <- names(discard(profiles_list, ~ .x$short_name %in% c("ALL", "SHI")))
+
+        # with he exception of 'All Indicators' and 'LTMHI' profiles,
+        # return TRUE/FALSE for each profile
+        # if the
+        profile_disable <- map_lgl(
+          discard(profiles_list, ~ .x$short_name %in% c("ALL", "SHI")),
+          ~ !any(grepl(.x$short_name, geo_profiles))
+        )
+
         
+        profile_disable <- unname(profile_disable)
+
+
+
+        #disable invalid choices
+        updatePickerInput(
+          inputId = "profile_selector",
+          session = session,
+          choices = all_profiles, # this needs to be here towork!
+          choicesOpt = list(
+            disabled = profile_disable,
+            style = ifelse(profile_disable,
+                           yes = "color: rgba(119, 119, 119, 0.5);",
+                           no = "")
+          )
+        )
+
       })
-      
-      
-      # # update profile choices based on chosen dataset -----
-      observe({
 
-        available_profile_choices <- switch(input$dataset_selector,
-                                            "Main Dataset" = names(profiles_list),
-                                            "Inequalities Dataset" = names(Filter(function(x)  "simd_tab" %in% x$subtabs & x$active == TRUE, profiles_list)))
 
-        updateVirtualSelect(session = session,
-                            inputId = "profile_selector",
-                            choices = available_profile_choices)
+      # Update indicator choices depending on selected dataset, geography(s) and (optionally) profile(s)
+      observeEvent(c(input$geography_selector, input$profile_selector), {
+
+        # take selected dataset and filter on area selections
+        data <- selectedData()[code %in% input$geography_selector]
+
+
+        # if profile(s) have been selected then further filter the data
+        if(!is.null(input$profile_selector)){
+
+          # get short names for selected profiles
+          profile_regex <- profiles_list[input$profile_selector] |>
+            map_chr("short_name") |>
+            paste(collapse = "|")
+
+
+          data <- data |>
+            filter(grepl(profile_regex, profile_domain))
+        }
+
+        # get unique indicator names
+        valid_choices <- unique(data$indicator)
+
+        # update indicator filter choices
+        updatePickerInput(inputId = "indicator_selector", choices =  valid_choices)
+
       })
 
 
-      
-      
-      
-      ## reset all filters when 'clear filters' button is clicked 
+
+
+
+      ## reset all filters when 'clear filters' button is clicked
       observeEvent(input$clear_table_filters, {
-        
+
         # reset the dataset selector to "Main Dataset"
-        updateRadioButtons(session, 
-                                inputId = "dataset_selector", 
+        updateRadioButtons(session,
+                                inputId = "dataset_selector",
                                 selected = "Main Dataset")
-        
+
         # reset the geographies to those available for the main dataset
         jstreeUpdate(session, "geography_selector", main_data_geo_nodes)
-        
-        
+
+
         # reset the time period filter to max year per indicator
         updateRadioButtons(session = session,
                                 inputId = "time_period",
                                 selected = "Latest available year")
-        
+
         # reset the indicator list to those present in main dataset
         updateVirtualSelect(session = session,
                             inputId = "indicator",
                             selected = NULL,
                             choices = NULL)
-        
+
         # reset the profile filter
         updateVirtualSelect(session = session,
                             inputId = "profile_selector",
                             selected = NULL,
-                            choices = names(profiles_list))
-        
+                            choices = names(discard(profiles_list, ~ .x$short_name %in% c("ALL", "SHI"))))
+
       })
       
       
-      
+      output$row_count <- renderText({
+        nrow(tableData())
+      })
+
+
+
     ##############################.
     # DATA TABLE ----
     ##############################.
-      
+
       output$data_tab_table <- renderDT({
 
+
         datatable(tableData(),
-                  style = 'bootstrap', 
+                  style = 'bootstrap',
                   caption = sprintf('Total rows: %s', nrow(tableData())),
                   rownames = FALSE,
-                  options = list(scrollX = TRUE,
-                                 scrollY = "600px", 
-                                 pageLength = 20,
+                  options = list(#scrollX = TRUE,
+                                # scrollY = "600px",
+                                 pageLength = 100,
                                  searching = FALSE,
                                  language = list(
                                    zeroRecords = "Select atleast one geography to display results.")
                   ))
-        
-        
-        
+
+
+
       })
-      
-      
+
+
             ##################################.
             # Downloads ----
             ##################################.
@@ -427,9 +488,9 @@ data_tab_mod_Server <- function(id) {
             # data table bulk download (note this is a module )
             # note: use filename argument once data downloads PR merged
             download_data_btns_server(id = "datatable_downloads", data = tableData, file_name="ScotPHO_datatab_extract")
-      
-      
-      
+
+
+
     }
   )
 }

--- a/shiny_app/modules/visualisations/data_table_tab_mod.R
+++ b/shiny_app/modules/visualisations/data_table_tab_mod.R
@@ -319,7 +319,7 @@ data_tab_mod_Server <- function(id) {
         
         
         # Further filter indicators if a profile is selected
-        if (!is.null(input$profile_selector) && input$profile_selector != "") {
+        if (!is.null(input$profile_selector)) {
           
           profile_filtered_data <- data |>
             filter(grepl(paste(profiles_list[[input$profile_selector]]$short_name, collapse = "|"), profile_domain))

--- a/shiny_app/modules/visualisations/data_table_tab_mod.R
+++ b/shiny_app/modules/visualisations/data_table_tab_mod.R
@@ -128,8 +128,9 @@ data_tab_modUI <- function(id) {
             label = NULL,
             choices = NULL,
             multiple = TRUE,
-            options = list(container = "body") # ensures drop-down can be expanded outside the sidebar if needed
-          )
+            options = list(container = "body", # ensures drop-down can be expanded outside the sidebar if needed
+                           liveSearch = TRUE) #allows searching of indicators) 
+            )
         )
         ), # close sidebar
       
@@ -410,7 +411,7 @@ data_tab_mod_Server <- function(id) {
         valid_choices <- unique(data$indicator)
 
         # update indicator filter choices
-        updatePickerInput(inputId = "indicator_selector", choices =  valid_choices)
+        updatePickerInput(inputId = "indicator_selector", choices =  valid_choices, options = list(liveSearch = TRUE))
 
       })
 

--- a/shiny_app/modules/visualisations/data_table_tab_mod.R
+++ b/shiny_app/modules/visualisations/data_table_tab_mod.R
@@ -34,8 +34,9 @@ data_tab_modUI <- function(id) {
         # dataset selection filter
         card(
           card_header(
+            class = "d-flex justify-content-between",
             div("Dataset", span("*", class = "text-red")),
-            tooltip(
+            popover(
               bs_icon("info-circle"),
               "The main dataset contains data for all indicators at various geography levels.
                The inequalities dataset is a smaller subset of indicators and geographies,
@@ -54,14 +55,15 @@ data_tab_modUI <- function(id) {
           )
         ),
         
-        # quintile type filter (only if inequalities dataset is selected)
+        # quintile type filter (hidden by default - only shown if inequalities dataset is selected)
         hidden(
           div(
             id = ns("inequality_extras"),
             card(
               card_header(
+                class = "d-flex justify-content-between",
                 div("SIMD Quintile types", span("*", class = "text-red")),
-                tooltip(
+                popover(
                   bs_icon("info-circle"),
                   p("Scottish quintile 1 refers to the datazones containing the 20% most deprived population in Scotland. Local quintile 1 contains the datazones where the 20% most deprived population within a particular Health board or Council area reside."),
                   p("Scottish quintiles therefore highlight inequalities between Scotland’s most and least deprived population, while local quintiles show inequalities within an area.")
@@ -79,7 +81,6 @@ data_tab_modUI <- function(id) {
         ),
         
 
-        
         # Geography filters
         card(
           card_header(
@@ -103,7 +104,7 @@ data_tab_modUI <- function(id) {
           )
         ),
                                          
-        # profile filters
+        # profile filter
         card(
           card_header("Profiles", helpText("(optional)")),
           card_body(
@@ -111,14 +112,14 @@ data_tab_modUI <- function(id) {
             pickerInput(
               inputId = ns("profile_selector"),
               label = NULL,
-              choices = names(discard(profiles_list, ~ .x$short_name %in% c("ALL", "SHI"))),
+              choices = names(discard(profiles_list, ~ .x$short_name %in% c("ALL", "SHI"))), # exclude 'All indicators' and LTMHI profiles from choices
               multiple = TRUE,
-              options = list(container = "body")
+              options = list(container = "body") # ensures drop-down can be expanded outside the sidebar if needed
             )
           )
         ),
         
-        # indicator filters
+        # indicator filter
         card(
           card_header("Indicators", helpText("(optional)")),
           helpText("Filter dataset by indicators. Indicator choices are dependent on previous selections."),
@@ -127,7 +128,7 @@ data_tab_modUI <- function(id) {
             label = NULL,
             choices = NULL,
             multiple = TRUE,
-            options = list(container = "body")
+            options = list(container = "body") # ensures drop-down can be expanded outside the sidebar if needed
           )
         )
         ), # close sidebar
@@ -176,11 +177,6 @@ data_tab_mod_Server <- function(id) {
         })
       
 
-
-
-
-
-
       # data to display in table /download
       tableData <- reactive({
 
@@ -191,7 +187,7 @@ data_tab_mod_Server <- function(id) {
         data <- data[code %in% input$geography_selector]
 
 
-        # filter by quint type (if inequalities dataset selected)
+        # filter by quint type(s) (if inequalities dataset selected)
         if(input$dataset_selector == "Inequalities Dataset"){
         if(length(input$quint_type_selector) == 1){
           if("Scotland" %in% input$quint_type_selector){
@@ -206,16 +202,16 @@ data_tab_mod_Server <- function(id) {
         if(!is.null(input$profile_selector)){
 
           # find short 3-letter profile names from profiles list
-          # in global script for selected indicator and create regex
-          # "e.g. DRG|ALC" and alcohol are selected
+          # in global script for selected profile(s) and create regex
+          # to search for in dataset "e.g. DRG|ALC" 
           profile_regex <- profiles_list[input$profile_selector] |>
             map_chr("short_name") |>
             paste(collapse = "|")
 
           # filter rows where any of short names found in profile_domain column
+          # using regex created above 
           data <- data[grepl(profile_regex, profile_domain)]
         }
-
 
 
         # further filter by indicator (if any selected)
@@ -233,6 +229,7 @@ data_tab_mod_Server <- function(id) {
                  upper_confidence_interval = upci,
                  lower_confidence_interval = lowci)
 
+        
         # columns to return if main dataset was selected
         if(input$dataset_selector == "Main Dataset") {
 
@@ -326,7 +323,7 @@ data_tab_mod_Server <- function(id) {
         }
       })
       
-      # enable/disable quintile type filter depending on selecte geographies
+      # enable/disable quintile type filter depending on selected geographies
       # as only Scottish quintiles can be selected if no local areas selected
       observeEvent(input$geography_selector, {
         req(input$dataset_selector == "Inequalities Dataset")
@@ -351,7 +348,8 @@ data_tab_mod_Server <- function(id) {
       observeEvent(c(input$geography_selector, selectedData()), {
         req(input$geography_selector) # don't run until a geography has been selected
 
-        # further filter selected dataset by selected geographies
+        # further filter selected dataset by selected geographies and return unique values
+        # in profile_domain column 
         geo_profiles <- unique(selectedData()[code %in% input$geography_selector, profile_domain])
 
         # get names of profiles excluding 'All Indicators' and 'Long-term Montitoring of HE'
@@ -359,23 +357,24 @@ data_tab_mod_Server <- function(id) {
         all_profiles <- names(discard(profiles_list, ~ .x$short_name %in% c("ALL", "SHI")))
 
         # with he exception of 'All Indicators' and 'LTMHI' profiles,
-        # return TRUE/FALSE for each profile
-        # if the
+        # go through each profile in the profiles list from global script and 
+        # return TRUE if the profile should be disabled or FALSE if it should be enabled 
+        # e.g. if 'ALC' is not found in 'geo_profiles' then return TRUE else FALSE
         profile_disable <- map_lgl(
           discard(profiles_list, ~ .x$short_name %in% c("ALL", "SHI")),
           ~ !any(grepl(.x$short_name, geo_profiles))
         )
 
-        
+        # convert named vector created above to unnamed vector
         profile_disable <- unname(profile_disable)
 
 
 
-        #disable invalid choices
+        # disable invalid choices
         updatePickerInput(
           inputId = "profile_selector",
           session = session,
-          choices = all_profiles, # this needs to be here towork!
+          choices = all_profiles,
           choicesOpt = list(
             disabled = profile_disable,
             style = ifelse(profile_disable,
@@ -428,13 +427,11 @@ data_tab_mod_Server <- function(id) {
                                 selected = "Main Dataset")
 
         # reset the geographies to those available for the main dataset
-        jstreeUpdate(session, "geography_selector", main_data_geo_nodes)
+        updateQuercusInput(session = session,
+                           inputId = "geography_selector", 
+                           choices = main_data_geo_nodes)
 
 
-        # reset the time period filter to max year per indicator
-        updateRadioButtons(session = session,
-                                inputId = "time_period",
-                                selected = "Latest available year")
 
         # reset the indicator list to those present in main dataset
         updateVirtualSelect(session = session,
@@ -451,6 +448,7 @@ data_tab_mod_Server <- function(id) {
       })
       
       
+      # return number of rows in filtered dataset
       output$row_count <- renderText({
         nrow(tableData())
       })
@@ -485,8 +483,7 @@ data_tab_mod_Server <- function(id) {
             # Downloads ----
             ##################################.
 
-            # data table bulk download (note this is a module )
-            # note: use filename argument once data downloads PR merged
+            # data table bulk download 
             download_data_btns_server(id = "datatable_downloads", data = tableData, file_name="ScotPHO_datatab_extract")
 
 


### PR DESCRIPTION
Fixing issues with the data table tab, mainly around profile filtering, e.g. not being able to filter on more than one profile and profiles appearing as an option even when it was invalid based on the selected geography, since e.g. some profiles have no indicators with IZ/locality level data. 

Also addressing some questions/requests that have previously come into the mailbox by making clearer the order filters should be applied, e.g. which are mandatory/optional, allowing selection of both local and Scottish quintiles (had this request from Highland before).

The latest version of the shinyWidgets now includes [quercusInput()](https://dreamrs.github.io/shinyWidgets/reference/quercusInput.html) for creating hierarchical  filters, meaning we no longer need a separate package (jsTreeR) just for this. You will need to have have version 0.9.1 installed. 

It also means the creation of both ‘main_dataset_geo_nodes.rds’ and ‘geo_lookup.rds’ can be simplified in data prep. The main_dataset_geo_nodes file is still needed for the filter choices but it's a much simpler nested list. We also previously had to create a ‘geo_path’ column in the geo_lookup to add to the indicator datasets for identifying which geographies had been selected in the old hierarchy filter which returned info about the selected areas like this: ‘Health board/NHS Ayrshire & Arran’. Now, we can just filter selected areas using the existing geography code column.

Also switching the file_snapshot args to FALSE by default, since I keep accidentally taking snapshots when I’m not actually deploying the app!