### PR TITLE
Mm climate wording tweaks

### DIFF
--- a/data_preparation/1_ScotPHO_profiles_data_preparation.R
+++ b/data_preparation/1_ScotPHO_profiles_data_preparation.R
@@ -213,10 +213,8 @@ climate_popgrp <- create_dataset(
 )
 
 
-# temporary step until climate pop_grp indicators available again
-popgrp_dataset <-scotpho_popgrp
 # combine all popgroup datasets
-#popgrp_dataset <- rbind(scotpho_popgrp, climate_popgrp)
+popgrp_dataset <- rbind(scotpho_popgrp, climate_popgrp)
 
 
 # save popgroup dataset in this projects data folder, ready to be used in the app

--- a/shiny_app/narrative/about_profiles_narrative.R
+++ b/shiny_app/narrative/about_profiles_narrative.R
@@ -393,7 +393,7 @@ about_cli_text <- navset_pill_list(
       accordion_panel(
         title = "Climate Health Impacts",
         p("These indicators were revised on 12 May 2026, following an error found in the first release. 
-          For details regarding this revision, please see our  ‘Heat impacts on health in Scotland: Deaths 2005-2024’ publication.", class "text-red"),
+          For details regarding this revision, please see our  ‘Heat impacts on health in Scotland: Deaths 2005-2024’ publication.", class = "text-red"),
         p("Provides modelled estimates for the number and rate of deaths attributable to heat, based on PHS’ recent 
         ‘Heat impacts on health in Scotland: Deaths 2005-2024’ publication. It must be noted these indicators are our best estimate for the 
         number of deaths and the rate of deaths per 100,000 population, not the observed number or crude rate.

--- a/shiny_app/narrative/about_profiles_narrative.R
+++ b/shiny_app/narrative/about_profiles_narrative.R
@@ -392,8 +392,6 @@ about_cli_text <- navset_pill_list(
       open = FALSE,
       accordion_panel(
         title = "Climate Health Impacts",
-        p("These indicators were revised on 12 May 2026, following an error found in the first release. 
-          For details regarding this revision, please see our  ‘Heat impacts on health in Scotland: Deaths 2005-2024’ publication.", class = "text-red"),
         p("Provides modelled estimates for the number and rate of deaths attributable to heat, based on PHS’ recent 
         ‘Heat impacts on health in Scotland: Deaths 2005-2024’ publication. It must be noted these indicators are our best estimate for the 
         number of deaths and the rate of deaths per 100,000 population, not the observed number or crude rate.
@@ -435,6 +433,8 @@ about_cli_text <- navset_pill_list(
   
   nav_panel("Climate Health Impacts",
             h3("Climate Health Impacts"),
+            p("These indicators were revised on 12 May 2026, following an error found in the first release. 
+          For details regarding this revision, please see our  ‘Heat impacts on health in Scotland: Deaths 2005-2024’ publication.", class = "text-red"),
             p("The Climate Health Impacts domain includes indicators linked to PHS’ recent",
               tags$a("‘Heat impacts on health in Scotland: Deaths 2005-2024’", href = "https://publichealthscotland.scot/publications/heat-impacts-on-health-in-scotland/heat-impacts-on-health-in-scotland-28-october-2025/", target = "_blank")," publication. They are part of a wider project to develop a full suite for the impacts of Climate on Health, and in the future will include the Health Impacts from cold and flooding. The feasibility of these indicators is explored 
             in the ",

--- a/shiny_app/narrative/about_profiles_narrative.R
+++ b/shiny_app/narrative/about_profiles_narrative.R
@@ -392,6 +392,8 @@ about_cli_text <- navset_pill_list(
       open = FALSE,
       accordion_panel(
         title = "Climate Health Impacts",
+        p("These indicators were revised on 12 May 2026, following an error found in the first release. 
+          For details regarding this revision, please see our  ‘Heat impacts on health in Scotland: Deaths 2005-2024’ publication.", class "text-red"),
         p("Provides modelled estimates for the number and rate of deaths attributable to heat, based on PHS’ recent 
         ‘Heat impacts on health in Scotland: Deaths 2005-2024’ publication. It must be noted these indicators are our best estimate for the 
         number of deaths and the rate of deaths per 100,000 population, not the observed number or crude rate.
@@ -471,7 +473,7 @@ about_cli_text <- navset_pill_list(
     br(),
     
     div(
-      p("3) Number of days at or above (25°C)", style = "font-weight: bold;"),
+      p("3) Number of days at or above 25°C", style = "font-weight: bold;"),
       p("This third indicator extracts the number of days for a given region that are at or above 25°C. 
         Available at Scotland, Health Board and Intermediate Zone level.")
     ),

--- a/shiny_app/narrative/about_profiles_narrative.R
+++ b/shiny_app/narrative/about_profiles_narrative.R
@@ -401,10 +401,8 @@ about_cli_text <- navset_pill_list(
       accordion_panel(
         title = "Weather",
         p("To place climate health impacts in context, it is useful to understand the temperature trends around Scotland. 
-        We have therefore included two indicators for the mean and maximum summer temperatures. Additionally, in the 
-        ‘Heat impacts on health in Scotland: Deaths 2005-2024’ publication, 22.6°C was identified as the threshold at which the population 
-        is at a 10% higher risk of death than at safe temperatures. As such, we have included an extra indicator of ‘Number of Days over 22.6°C’.
-        Available at Scotland, Health Board, Council Area and Intermediate Zone level."
+        We have therefore included two indicators for the mean and maximum summer temperatures. Additionally, we have included 
+        an extra indicator of ‘Number of Days at or over 25°C’. Available at Scotland, Health Board, Council Area and Intermediate Zone level."
           )
         ),
       
@@ -441,12 +439,13 @@ about_cli_text <- navset_pill_list(
               tags$a("PHS Climate Impact Indicators (CII) Feasibility Report", href = "https://publichealthscotland.scot/publications/phs-climate-impact-indicators-cii-feasibility-report/", target = "_blank"),
             ". At present, there are two ScotPHO Climate indicators from this publication:"),
             tags$ul(
-            tags$li("Modelled rate of deaths attributable to heat over the risk increase threshold (18.2°C)"),
-            tags$li("Modelled number of deaths attributable to heat over the risk increase threshold (18.2°C)")
+            tags$li("Modelled rate of deaths attributable to heat over the risk increase threshold (20.7°C)"),
+            tags$li("Modelled number of deaths attributable to heat over the risk increase threshold (20.7°C)")
             ),
-            p("These are calculated using a Distributed Lag Non-linear model and are our best estimate for the number of deaths and the rate of deaths per 100,000 population. 
-              18.2°C has been identified in our publication as the ‘Risk Increase Threshold’, that is ‘the threshold at which the relative risk of death starts to increase significantly 
-              (i.e. the lower confidence interval for the relative risk of death is above 1). For detailed methodology, see ‘Health Impacts from Heat: 2005-2024’."),
+            p("These are calculated using a Distributed Lag Non-linear model and are our best estimate for the number of deaths and the 
+              rate of deaths per 100,000 population. 20.7°C has been identified in our publication as the ‘Risk Increase Threshold’, 
+              that is ‘the threshold at which the relative risk of death starts to increase significantly (i.e. the lower confidence 
+              interval for the relative risk of death is above 1). For detailed methodology, see ‘Health Impacts from Heat: 2005-2024’."),
             br()
   ),
   
@@ -472,10 +471,9 @@ about_cli_text <- navset_pill_list(
     br(),
     
     div(
-      p("3) Number of days over high-risk threshold (22.6°C)", style = "font-weight: bold;"),
-      p("In the ‘Heat impacts on health in Scotland: Deaths 2005-2024’ publication, 22.6°C was identified as the High-Risk Threshold for deaths associated 
-    with heat. At this threshold, the population is at a 10% higher risk than it is at safe temperatures. This third indicator extracts 
-    the number of days for a given region that are above this temperature.Available at Scotland, Health Board and Intermediate Zone level.")
+      p("3) Number of days at or above (25°C)", style = "font-weight: bold;"),
+      p("This third indicator extracts the number of days for a given region that are at or above 25°C. 
+        Available at Scotland, Health Board and Intermediate Zone level.")
     ),
     br()
     ),

--- a/shiny_app/ui.R
+++ b/shiny_app/ui.R
@@ -267,29 +267,14 @@ page_navbar(
                                  # only display this when Climate change is selected
                                  # contains links to info about profile and related publication
                                  conditionalPanel(condition = "input.profile_choices == 'Climate'",
-                                                  # temporarily comment out until the climate team correct indicators
-                                                  # div(style = "padding: 10px; background-color: #F5ECF4;",
-                                                  #     p(bs_icon("info-circle-fill", size = "1.2em"), " Read more about the new",
-                                                  #       actionLink(inputId = "cli_about_link", label = "climate profile"), 
-                                                  #       " and access the associated report on the Public Health Scotland website:", 
-                                                  #       tags$a("‘Heat impacts on health in Scotland: Deaths 2005-2024’", href = "https://publichealthscotland.scot/publications/heat-impacts-on-health-in-scotland/heat-impacts-on-health-in-scotland-28-october-2025/", target = "_blank")
-                                                  #       )
-                                                  #     )
-                                                  
-                                                  # temporary notice about climate profile indicators being removed
-                                                  card(
-                                                    class = "m-2",
-                                                    card_header(bs_icon("info-circle-fill", size = "1.2em"),"Important notice",class = "info-box-header"),
-                                                    card_body(
-                                                      p("The", tags$a("‘Heat impacts on health in Scotland: Deaths 2005-2024’", href = "https://publichealthscotland.scot/publications/heat-impacts-on-health-in-scotland/heat-impacts-on-health-in-scotland-28-october-2025/", target = "_blank"),
-                                                        "has been temporarily removed from the public domain while the Climate Analyst Team investigates an error in the code. 
-                                                        It is expected to have affected indicators related to risk thresholds and modelled deaths estimates. 
-                                                        These have temporarily been removed from the profiles tool. The Climate Analyst Team is working to fix the error 
-                                                        and update the results accordingly. The corrected report will be released in May. For any questions, please contact", 
-                                                        tags$a("phs.climateanalysis@phs.scot", href = "mailto::phs.climateanalysis@phs.scot", target = "_blank")
+                                                  div(style = "padding: 10px; background-color: #F5ECF4;",
+                                                      p(bs_icon("info-circle-fill", size = "1.2em"), " Read more about the new",
+                                                        actionLink(inputId = "cli_about_link", label = "climate profile"),
+                                                        " and access the associated report on the Public Health Scotland website:",
+                                                        tags$a("‘Heat impacts on health in Scotland: Deaths 2005-2024’", href = "https://publichealthscotland.scot/publications/heat-impacts-on-health-in-scotland/heat-impacts-on-health-in-scotland-28-october-2025/", target = "_blank")
                                                         )
                                                       )
-                                                    )
+
                                                   ), # close conditional panel
                                                       
 


### PR DESCRIPTION
Not much to check here, more for awareness.

Some wording tweaks for the climate profile following revised heath related deaths publication out tomorrow (12th). This means original indicators are being added back into the app.

There was also a temp step added into data prep because there was no popgroup data for the climate profile when the indicators were removed. Temp step has been removed.