### PR TITLE
RII tweaks

### DIFF
--- a/shiny_app/modules/visualisations/data_table_tab_mod.R
+++ b/shiny_app/modules/visualisations/data_table_tab_mod.R
@@ -257,7 +257,7 @@ data_tab_mod_Server <- function(id) {
                               quintile = NULL
                        )
 
-                     # rii data
+                     # rii data - simple
                      rii <- data |>
                        filter(quintile == "Total") |>
                        mutate(value = rii,
@@ -266,20 +266,29 @@ data_tab_mod_Server <- function(id) {
                        mutate(measure = "Relative index of inequality (RII)",
                               quintile = NULL)
 
+                     # rii data - as %
+                     rii_int <- data |>
+                       filter(quintile == "Total") |>
+                       mutate(value = rii_int,
+                              upper_confidence_interval = upci_rii_int,
+                              lower_confidence_interval = lowci_rii_int) |>
+                       mutate(measure = "Relative index of inequality (RII) as %",
+                              quintile = NULL)
+                     
                      # par data
                      par <- data |>
                        filter(quintile == "Total") |>
                        mutate(value = par,
-                              upper_confidence_interval = upci_rii_int,
-                              lower_confidence_interval = lowci_rii_int) |>
+                              upper_confidence_interval = 0, # there are no CI around PAR
+                              lower_confidence_interval = 0) |> # there are no CI around PAR
                        mutate(measure = "Population attributable risk (PAR)",
                               quintile = NULL)
 
                      # different inequalities measures combined
-                     data <- bind_rows(data, rii, sii, par) |>
+                     data <- bind_rows(data, rii, rii_int, sii, par) |>
                        select(area_code, area_type, area_name, year, period, indicator,
-                              quint_type, quintile, measure, value, upper_confidence_interval,
-                              lower_confidence_interval) |>
+                              quint_type, quintile, measure, value, lower_confidence_interval,
+                              upper_confidence_interval) |>
                        arrange(indicator, area_name, year)
                    }
 

--- a/shiny_app/modules/visualisations/simd_mod.R
+++ b/shiny_app/modules/visualisations/simd_mod.R
@@ -540,7 +540,7 @@ simd_navpanel_ui <- function(id) {
                # RII trend chart titles/subtitles/interpretation/filename
                right_chart_narrative = about_rii,
                right_chart_title = paste0("Inequalities over time: relative differences"),
-               right_chart_subtitle_1 = "The chart shows the differences between the most disadvantaged area and the overall average for Scotland (expressed as a percentage).",
+               right_chart_subtitle_1 = "The chart shows the differences between the most disadvantaged area and the overall average for your selected area (expressed as a percentage).",
                right_chart_subtitle_2 = "An increasing trend suggests that the gap between the most disadvantaged area and the average is growing",
                right_chart_filename = paste0("ScotPHO RII chart - ", selected_indicator())
              ),

--- a/shiny_app/modules/visualisations/simd_mod.R
+++ b/shiny_app/modules/visualisations/simd_mod.R
@@ -441,7 +441,7 @@ simd_navpanel_ui <- function(id) {
                                                upci_rii_int = colDef(show = FALSE),
                                                lowci_rii_int = colDef(show = FALSE),
                                                trend_axis = colDef(name = "Time period"),
-                                               rii_int = colDef(name = "Relative index of inequality (RII)")
+                                               rii_int = colDef(name = "Relative index of inequality (RII) as %")
                        )
                      ),
                      


### PR DESCRIPTION
minor adjustments so that bulk download now includes both the simple RII value and the RII expressed as a %. I've also removed CI from the PAR statistic as i've realised we don't calculate these so the CI were mistakenly being pulled in from elsewhere.