### PR TITLE
Adding licensing info to the app

### DIFF
--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,0 +1,39 @@
+#MIT License
+
+The source code in this repository is available under the MIT License. 
+
+Copyright (c) 2026 Public Health Scotland
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+#Open Government Licence (OGL) v3.0
+
+This application utilises public sector indicators and datasets. Unless 
+otherwise stated, all underlying data is licensed under the Open Government 
+Licence v3.0 (OGL v3.0).
+
+Attribution Statement:
+"Contains public sector information licensed under the Open Government 
+Licence v3.0."
+
+Licence Terms: https://nationalarchives.gov.uk
+
+A comprehensive index of all specific indicators, datasets, and their 
+respective government sources can be found in the accompanying 
+DATA_SOURCES.md file in this repository.

--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ Within this folder is a master script '1_ScotPHO_profiles_data_prepartion' that 
 
 ## shiny_app
 Within this folder are scripts require for functioning of the profiles tool shiny app
+
+##Licensing
+Source code: Licensed under the MIT License. 
+Underlying Data: Licensed under the Open Government Licence (OGL) v3.0.
+Visualisations: This application utilises the highcharter R package, which depends on the proprietary Highcharts JavaScript library. Our organisation maintains a paid license for this.
+
+Note for downstream users: If you clone or fork this repository to run or distribute your own version of this application, you are responsible for securing your own commercial or governmental license from Highcharts to comply with their End User License Agreement (EULA).
+


### PR DESCRIPTION
Hi both, 

I've done some digging with the help of the data science team into the licensing of the app. The short version is that the data we're using are available under the Open Government Licence (OGL), but this is not applicable to code. To licence the code we need to use the MIT licence as required by the SG. 

I've added a LICENCE markdown file which outlines the 2 licences in use for the profiles tool. I've also added these to the main read me you can see on the repo, including highlighting that there's a different licensing arrangement for Highcharter. I'll look to add the OGL bit to indicator production as well

Abbie