### PR TITLE
Mm bookmark profile

### DIFF
--- a/shiny_app/modules/visualisations/summary_table_mod.R
+++ b/shiny_app/modules/visualisations/summary_table_mod.R
@@ -20,7 +20,7 @@
 
 summary_table_ui <- function(id) {
   ns <- NS(id)
-  tagList(
+  page_fixed(
     
     # enable guided tour
     # use_cicerone(),
@@ -695,6 +695,19 @@ summary_table_server <- function(id, selected_geo, selected_profile, filtered_da
     observeEvent(input$summary_tour_button, {
       guide_summary$start()
     })
+    
+    
+    # MM note June 2026:
+    # prevent these from appearing in any bookmarked urls
+    # to be revisited to understand why they would appear!
+    setBookmarkExclude(
+      c(session$getBookmarkExclude(), 
+        "summary_table__reactable__page",
+        "summary_table__reactable__pageSize",
+        "summary_table__reactable__pages",
+        "summary_table__reactable__sorted",
+        "summary_table__reactable__selected"
+        ))
     
  
        

--- a/shiny_app/modules/visualisations/summary_table_mod.R
+++ b/shiny_app/modules/visualisations/summary_table_mod.R
@@ -695,22 +695,6 @@ summary_table_server <- function(id, selected_geo, selected_profile, filtered_da
     observeEvent(input$summary_tour_button, {
       guide_summary$start()
     })
-    
-    
-    # MM note June 2026:
-    # prevent these from appearing in any bookmarked urls
-    # to be revisited to understand why they would appear!
-    setBookmarkExclude(
-      c(session$getBookmarkExclude(), 
-        "summary_table__reactable__page",
-        "summary_table__reactable__pageSize",
-        "summary_table__reactable__pages",
-        "summary_table__reactable__sorted",
-        "summary_table__reactable__selected"
-        ))
-    
- 
-       
 
   }) # close module server
 } # close module

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -492,13 +492,15 @@ function(input, output, session) {
     # that this object usually only updates when 'apply filters' button
     # is clicked - i.e. this is the same code that runs in response to button click
     # further up this script
-    geo_selections(
-      list(
-        areatype = state$input$areatype,
-        areaname = state$input$areaname,
-        parent_area = state$input$parent_area
+    if(state$input$nav == "Profiles"){
+      geo_selections(
+        list(
+          areatype = state$input$areatype,
+          areaname = state$input$areaname,
+          parent_area = state$input$parent_area
+        )
       )
-    )
+    }
     
   })
   

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -183,9 +183,17 @@ function(input, output, session) {
   })
   
   
+  ###############################################################.
+  # CONDITIONALLY SHOWING INFO CARDS FOR SPECIFIC PROFILES ----
+  ###############################################################.
+  # A couple of profiles have an info card about their summary table that is hidden in the UI
+  # This code shows/hides these cards when applicable
+  observeEvent(input$profile_choices, {
+    toggle(id = "CWB_banner", condition = input$profile_choices == "Population Health")
+    toggle(id = "CMH_banner", condition = input$profile_choices == "Children & Young People Mental Health")
+  })
   
-  
-  
+
   
   ###############################################################.
   # DETERMINING WHICH SUB-TABS TO SHOW/HIDE ON THE PROFILES TAB ----
@@ -428,7 +436,7 @@ function(input, output, session) {
         title = "Bookmark link",
         easyClose = TRUE,
         size = "l",
-        "Copy link below to share with others:",
+        "This URL preserves your current profile and geography choices, allowing you to return to the same view later or share it with others.",
         # have to use shiny fluidRow and column here
         # instead of bslib layout_columns as throws an error
         # for some reason!

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -95,9 +95,9 @@ function(input, output, session) {
   observeEvent(input$apply_geo_filters, {
     geo_selections(
       list(
-        areatype = input$areatype, # selected areatype 
-        areaname = input$areaname, # selected areaname 
-        parent_area = input$parent_area # selected parent area (only applicable if HSC locality/Intermediate zone is selected)
+       areatype = input$areatype,
+       parent_area = ifelse(input$areatype %in% c("HSC Locality", "Intermediate zone"), input$parent_area, NA),
+       areaname = ifelse(input$areatype == "Scotland", "Scotland", input$areaname)
       )
     )
   })
@@ -511,6 +511,8 @@ function(input, output, session) {
         )
       )
     }
+    
+
     
   })
   

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -333,6 +333,20 @@ function(input, output, session) {
   })
   
   
+  # if a user clicks directly on the 'Profiles' tab in the navbar
+  # without clicking a profile button on the homepage (resulting in input$profile_choices not updating), 
+  # then select 'Health & Wellbeing' profile so there's always something displayed
+  observeEvent(input$nav, {
+    req(input$nav == "Profiles")
+    if(input$profile_choices == ""){
+    updateSelectizeInput(
+      inputId = "profile_choices",
+      selected = "Health & Wellbeing"
+    )
+    }
+  })
+  
+  
   
   ###########################################.
   # Bookmarking ------
@@ -344,31 +358,27 @@ function(input, output, session) {
 
   # 1. Bookmark exclusions ----
   
-  # Temporary step to remove all inputs from the bookmarked URL
-  # except those related to the LTMHI profile (and the selected nav)
-  # The LTMHI module (and other modules used within that) will also
-  # be applying further exclusions to ltmhi-related inputs
+  # Step to remove inputs from a bookmarked URL, depending on
+  # what tab your on (currently only relevant to the LTMHI and Profile tabs 
   # This code runs whenever uses switches tabs along the main navbar
   observeEvent(input$nav, {
     
     # only run when user on ltmhi or profiles tab
-    # not relevant to other tabs
+    # not currently relevant to other tabs
     req(input$nav %in% c("shi_tab", "Profiles"))  
     
     # ids of all inputs from across the app
     all_inputs <- names(input)
-    
-    # those related to LTMHI only
-    ltmhi_tab_inputs <- all_inputs[grepl("ltmhi", all_inputs)]
-    
-    # global geography and profile filter input ids
-    profile_tab_inputs <- c("areatype", "areaname", "parent_area", "profile_choices")
-    
-    # inputs to bookmark 
-    inclusions <- c("nav", # selected tab from main navbar
-                    if(input$nav == "shi_tab") ltmhi_tab_inputs,
-                    if(input$nav == "Profiles") profile_tab_inputs
-                    )
+
+    # inputs to bookmark, depending on what tab your on 
+    inclusions <- c(
+      # selected tab from main navbar (always to be included)
+      "nav",
+      # inputs related to the LTMTI tab only 
+      if(input$nav == "shi_tab") all_inputs[grepl("ltmhi", all_inputs)],
+      # inputs related to the Profiles tab only (i.e. globally selected geography and profile)
+      if(input$nav == "Profiles") c("areatype", "areaname", "parent_area", "profile_choices")
+      )
 
     # inputs to exclude
     exclusions <- setdiff(all_inputs, inclusions)

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -112,6 +112,7 @@ function(input, output, session) {
   # 3. storing full and short name of the selected profile ( Currently, this particular info is only being used in the 
   # trend module to ensure that police divisions only appear as a filter if mental health is selected)
   selected_profile <- reactive({
+    req(input$profile_choices != "")
     list(
       full_name = input$profile_choices, 
       short_name = pluck(profiles_list, input$profile_choices, "short_name"),
@@ -347,23 +348,38 @@ function(input, output, session) {
   # except those related to the LTMHI profile (and the selected nav)
   # The LTMHI module (and other modules used within that) will also
   # be applying further exclusions to ltmhi-related inputs
-  # This code is only run once when the app initally loads
+  # This code runs whenever uses switches tabs along the main navbar
   observeEvent(input$nav, {
-
+    
+    # only run when user on ltmhi or profiles tab
+    # not relevant to other tabs
+    req(input$nav %in% c("shi_tab", "Profiles"))  
+    
     # ids of all inputs from across the app
     all_inputs <- names(input)
-
+    
     # those related to LTMHI only
-    ltmhi_inputs <- all_inputs[grepl("ltmhi", all_inputs)]
+    ltmhi_tab_inputs <- all_inputs[grepl("ltmhi", all_inputs)]
+    
+    # global geography and profile filter input ids
+    profile_tab_inputs <- c("areatype", "areaname", "parent_area", "profile_choices")
+    
+    # inputs to bookmark 
+    inclusions <- c("nav", # selected tab from main navbar
+                    if(input$nav == "shi_tab") ltmhi_tab_inputs,
+                    if(input$nav == "Profiles") profile_tab_inputs
+                    )
 
-    # inputs to exclude 
-    exclusions <- setdiff(all_inputs, c(ltmhi_inputs, "nav"))
+    # inputs to exclude
+    exclusions <- setdiff(all_inputs, inclusions)
     
     # apply exclusions
     setBookmarkExclude(exclusions)
+    
+    
+  }, ignoreInit = TRUE)
+  
 
-
-  }, ignoreInit = FALSE, once = TRUE)
   
   
   # 2 additional inputs to be excluded (these are created within the popup modal that appears during 
@@ -470,6 +486,20 @@ function(input, output, session) {
     if(!is.null(card_id)){
       session$sendCustomMessage("fullscreen_card", card_id)
     }
+    
+    # update geo_selections() reactive values object with the
+    # bookmarked geography filter selections - this gets around the fact
+    # that this object usually only updates when 'apply filters' button
+    # is clicked - i.e. this is the same code that runs in response to button click
+    # further up this script
+    geo_selections(
+      list(
+        areatype = state$input$areatype,
+        areaname = state$input$areaname,
+        parent_area = state$input$parent_area
+      )
+    )
+    
   })
   
   

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -384,8 +384,9 @@ function(input, output, session) {
       "nav",
       # inputs related to the LTMTI tab only 
       if(input$nav == "shi_tab") all_inputs[grepl("ltmhi", all_inputs)],
-      # inputs related to the Profiles tab only (i.e. globally selected geography and profile)
-      if(input$nav == "Profiles") c("areatype", "areaname", "parent_area", "profile_choices")
+      # inputs related to the Profiles tab only (i.e. globally selected profile)
+      # Note we don't include the 3 globally geography inputs - we use geo_selections reactive vals object instead
+      if(input$nav == "Profiles") c("profile_choices")
       )
     
     # inputs to exclude
@@ -425,11 +426,17 @@ function(input, output, session) {
     session$userData$share_card <- NULL
   })
   
-  #specifically excluding reactable inputs from summary tab which generate after the exclusions list
+  # specifically excluding reactable inputs from summary tab which generate after the exclusions list
   onBookmark(function(state) {
     reactable_ids <- grep("__reactable__", names(as.list(reactiveValuesToList(input))), value = TRUE)
     
     state$exclude <- unique(c(state$exclude, reactable_ids))
+  })
+  
+  
+  # save geo_selections reactive value object into a variable in the url called 'geography'
+  onBookmark(function(state) {
+    state$values$geography <- geo_selections()
   })
   
   
@@ -518,13 +525,7 @@ function(input, output, session) {
     # is clicked - i.e. this is the same code that runs in response to button click
     # further up this script
     if(state$input$nav == "Profiles"){
-      geo_selections(
-        list(
-          areatype = state$input$areatype,
-          areaname = state$input$areaname,
-          parent_area = state$input$parent_area
-        )
-      )
+      geo_selections(state$values$geography)
     }
     
 

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -387,13 +387,19 @@ function(input, output, session) {
       # inputs related to the Profiles tab only (i.e. globally selected geography and profile)
       if(input$nav == "Profiles") c("areatype", "areaname", "parent_area", "profile_choices")
       )
-
+    
     # inputs to exclude
     exclusions <- setdiff(all_inputs, inclusions)
     
+    #specifically excluding reactable inputs from summary tab which generate after the exclusions list
+    onBookmark(function(state) {
+      reactable_ids <- grep("__reactable__", names(as.list(reactiveValuesToList(input))), value = TRUE)
+
+      state$exclude <- unique(c(state$exclude, reactable_ids))
+    })
+    
     # apply exclusions
     setBookmarkExclude(exclusions)
-    
     
   }, ignoreInit = TRUE)
   

--- a/shiny_app/server.R
+++ b/shiny_app/server.R
@@ -390,13 +390,7 @@ function(input, output, session) {
     
     # inputs to exclude
     exclusions <- setdiff(all_inputs, inclusions)
-    
-    #specifically excluding reactable inputs from summary tab which generate after the exclusions list
-    onBookmark(function(state) {
-      reactable_ids <- grep("__reactable__", names(as.list(reactiveValuesToList(input))), value = TRUE)
-
-      state$exclude <- unique(c(state$exclude, reactable_ids))
-    })
+  
     
     # apply exclusions
     setBookmarkExclude(exclusions)
@@ -429,6 +423,13 @@ function(input, output, session) {
     
     # re-reset userData variable (updated within share card button module) called share_card back to NULL
     session$userData$share_card <- NULL
+  })
+  
+  #specifically excluding reactable inputs from summary tab which generate after the exclusions list
+  onBookmark(function(state) {
+    reactable_ids <- grep("__reactable__", names(as.list(reactiveValuesToList(input))), value = TRUE)
+    
+    state$exclude <- unique(c(state$exclude, reactable_ids))
   })
   
   

--- a/shiny_app/ui.R
+++ b/shiny_app/ui.R
@@ -204,7 +204,10 @@ page_navbar(
                 ),
   
               # bookmark button
-              bookmarkButton(),
+             div(
+               p("Click the button below to create a shareable link with your profile and geography selections."),
+              bookmarkButton()
+              ),
   
               # hidden geography filterers to display when button clicked
                 hidden(div(id = "geo_filters_hidden",

--- a/shiny_app/ui.R
+++ b/shiny_app/ui.R
@@ -205,7 +205,7 @@ page_navbar(
   
               # bookmark button
              div(
-               p("Click the button below to create a shareable link with your profile and geography selections."),
+               p("Save or share your profile and geography selections using the button below."),
               bookmarkButton(class = "btn-sm")
               ),
   
@@ -261,28 +261,28 @@ page_navbar(
                                  
                                  # Display message at top of summary tab for specific profiles only
                                  # commenting out Jan 2025 but leaving script as placeholder as new text may come along 
-                                 conditionalPanel(condition = "input.profile_choices == 'Population Health'",
-                                                  br(),
-                                                  card(max_height = 150,
-                                                       card_header(bs_icon("info-circle-fill", size = "1.2em"),"About this profile",class = "info-box-header"),
-                                                       p("The Population Health dashboard has been developed to support the ambitions of Scotland’s Population Health Framework, and the Collaboration 
-                                                         for Health Equity in Scotland by providing access to the latest data on population health outcomes and inequalities. The indicators are structured 
-                                                         around the “Marmot Eight” principles as laid out in the Institute of Health Equity’s work on ",
-                                                         tags$a("Marmot Places", href = "https://www.instituteofhealthequity.org/taking-action/marmot-places", target = "_blank"),". ",
+                                 hidden(
+                                   card(
+                                     id = "CWB_banner",
+                                     card_header(bs_icon("info-circle-fill", size = "1.2em"),"About this profile",class = "info-box-header"),
+                                     p("The Population Health dashboard has been developed to support the ambitions of Scotland’s Population Health Framework, and the Collaboration 
+                                        for Health Equity in Scotland by providing access to the latest data on population health outcomes and inequalities. The indicators are structured 
+                                         around the “Marmot Eight” principles as laid out in the Institute of Health Equity’s work on ",
+                                      tags$a("Marmot Places", href = "https://www.instituteofhealthequity.org/taking-action/marmot-places", target = "_blank"),". ",
                                                          "We are working with PHS to complete the indicator set and ensure each reflects the latest available data soon.")
-                                                       )
-                                                  ),
+                                     )
+                                   ),
   
                                  # only display this card when Mental Health profile selected
-                                 conditionalPanel(condition = "input.profile_choices == 'Children & Young People Mental Health'",
-                                                  br(),
-                                                  card(max_height = 150,
-                                                       card_header(bs_icon("info-circle-fill", size = "1.2em"),"Updates to this profile in Jan 2026:",class = "info-box-header"),
-                                                       p("Additional indicators about children's mental health outcomes have been added 
-                                                         (conduct problems, emotional symptoms, hyperactivity/inattention, prosocial behaviour, and peer relationship problems). 
-                                                         Also, the source of the data for 'children meeting physical activity guidelines' has changed, resulting in higher estimates. 
-                                                         See the indicator metadata for more information.")
-                                                  )
+                                 hidden(
+                                   card(
+                                     id = "CMH_banner",
+                                     card_header(bs_icon("info-circle-fill", size = "1.2em"),"Updates to this profile in Jan 2026:",class = "info-box-header"),
+                                     p("Additional indicators about children's mental health outcomes have been added 
+                                       (conduct problems, emotional symptoms, hyperactivity/inattention, prosocial behaviour, and peer relationship problems). 
+                                        Also, the source of the data for 'children meeting physical activity guidelines' has changed, resulting in higher estimates. 
+                                        See the indicator metadata for more information.")
+                                     )
                                  ),
                                  summary_table_ui("summary")
                                  ),

--- a/shiny_app/ui.R
+++ b/shiny_app/ui.R
@@ -193,14 +193,19 @@ page_navbar(
                 hidden(div(id = "prof_filter_hidden",
                       selectizeInput(inputId = "profile_choices", 
                                      label = NULL, 
-                                     choices = profile_filter_choices, #declared in global script
-                                     options = list(onInitialize = I('function() { this.setValue(""); }')))
+                                     choices = c("", profile_filter_choices), #declared in global script
+                                     selected = ""
+                                     )
                     )),
               # geography header with button
                 div(class = "header-elements",
                     tagAppendAttributes(class = "geography-header", h2(textOutput("geography_header"))),
                     actionButton("show_geo_filters", label = "Change area", icon = icon("filter"), class = "btn-sm ms-3 btn-global")
                 ),
+  
+              # bookmark button
+              bookmarkButton(),
+  
               # hidden geography filterers to display when button clicked
                 hidden(div(id = "geo_filters_hidden",
                 

--- a/shiny_app/ui.R
+++ b/shiny_app/ui.R
@@ -206,7 +206,7 @@ page_navbar(
               # bookmark button
              div(
                p("Click the button below to create a shareable link with your profile and geography selections."),
-              bookmarkButton()
+              bookmarkButton(class = "btn-sm")
               ),
   
               # hidden geography filterers to display when button clicked


### PR DESCRIPTION
Hey Abbie,

Some small changes to get bookmarking expanded. Hopefully my comments below make sense with the changes you see added/removed but if you have any questions let me know!

**Bookmarking code:**

- Adding bookmark button to the profiles tab (in UI script) and expanding bookmarking logic (in server script) to also save geography and profile selection.

**Other code related to bookmarking:**

- Some profiles have an info card above their summary table. They were shown/hidden in the Ui using conditionalPanel() but I’ve switched to them being hidden in the UI using hidden() and I’m conditionally showing/hiding using show()/hide() in the server instead. This is because when opening a bookmarked URL these cards were momentarily appearing before disappearing when using conditionalPanel which was a bit jumpy.
- Tweaking the way the default selected profile is set up in the profiles filter in the UI so that it’s an empty string until user makes selection. The way I had it set up before wasn’t working with bookmarking.
- For some reason some summary tab inputs directly linked to the summary table were showing in bookmarked URLs so I’m explicitly removing them within the summary tab module. Still need to investigate why they are appearing despite applying exclusions in the apps main server script.
- Making sure the parent_area value in geo_selections reactive values object is always set to NA if a user hasn’t selected a small areatype, e.g. previously when had small area selected, then switched to a larger area, the original parent_area was still being stored.

**Something unrelated**

- If a user navigates to the profiles tab without clicking one of the profile buttons, it should now pre-select health & wellbeing profile so that at least something is displayed. 
